### PR TITLE
fix(api): GSI KEYS_ONLY 前提で壊れていた /batches?status=X を 1+1 fetch に修正

### DIFF
--- a/lambda/api/__tests__/lib/batch-query.test.ts
+++ b/lambda/api/__tests__/lib/batch-query.test.ts
@@ -141,6 +141,73 @@ describe("BatchQuery", () => {
         JSON.parse(Buffer.from(cursor, "base64url").toString()),
       ).not.toThrow();
     });
+
+    it("GSI1 が KEYS_ONLY projection を返しても全属性を解決して返す", async () => {
+      // 本番 GSI1 は ``projectionType: KEYS_ONLY`` で、Query レスポンスは
+      // ``PK`` / ``SK`` / ``GSI1PK`` / ``GSI1SK`` のみ。``batchJobId`` /
+      // ``status`` / ``totals`` / ``basePath`` 等は含まれないため、追加の
+      // BatchGetItem で本体を取得する必要がある。
+      mockSend
+        .mockResolvedValueOnce({
+          // 1st call: GSI1 Query — keys のみ
+          Items: [
+            {
+              PK: "BATCH#batch-001",
+              SK: "META",
+              GSI1PK: "STATUS#COMPLETED#202604",
+              GSI1SK: "2026-04-22T00:00:00Z",
+            },
+          ],
+          LastEvaluatedKey: undefined,
+        })
+        .mockResolvedValueOnce({
+          // 2nd call: BatchGetCommand — 本体属性を含むフル META
+          Responses: {
+            [TABLE]: [
+              {
+                PK: "BATCH#batch-001",
+                SK: "META",
+                entityType: "BATCH",
+                batchJobId: "batch-001",
+                status: "COMPLETED",
+                totals: { total: 2, succeeded: 2, failed: 0, inProgress: 0 },
+                basePath: "project/2026",
+                createdAt: "2026-04-22T00:00:00Z",
+                startedAt: "2026-04-22T00:00:10Z",
+                updatedAt: "2026-04-22T00:10:00Z",
+                parentBatchJobId: null,
+              },
+            ],
+          },
+        });
+
+      const result = await query.listBatchesByStatus("COMPLETED", "202604");
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({
+        batchJobId: "batch-001",
+        status: "COMPLETED",
+        totals: { total: 2, succeeded: 2, failed: 0, inProgress: 0 },
+        basePath: "project/2026",
+        createdAt: "2026-04-22T00:00:00Z",
+        startedAt: "2026-04-22T00:00:10Z",
+        updatedAt: "2026-04-22T00:10:00Z",
+        parentBatchJobId: null,
+      });
+      // 2 回呼ばれる (Query + BatchGetItem)
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it("GSI1 が空なら BatchGetItem は呼ばず空リストを返す", async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [],
+        LastEvaluatedKey: undefined,
+      });
+      const result = await query.listBatchesByStatus("PENDING", "202604");
+      expect(result.items).toEqual([]);
+      expect(result.cursor).toBeNull();
+      // Query 1 回のみ (BatchGetCommand は発行されない)
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
   });
 
   // --- listChildBatches ---
@@ -155,6 +222,45 @@ describe("BatchQuery", () => {
       expect(cmd.input.ExpressionAttributeValues[":gsi2pk"]).toBe(
         "PARENT#parent-batch-001",
       );
+    });
+
+    it("GSI2 が KEYS_ONLY projection を返しても全属性を解決して返す", async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Items: [
+            {
+              PK: "BATCH#child-001",
+              SK: "META",
+              GSI2PK: "PARENT#parent-batch-001",
+              GSI2SK: "2026-04-22T00:00:00Z",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          Responses: {
+            [TABLE]: [
+              {
+                PK: "BATCH#child-001",
+                SK: "META",
+                entityType: "BATCH",
+                batchJobId: "child-001",
+                status: "PENDING",
+                totals: { total: 1, succeeded: 0, failed: 0, inProgress: 1 },
+                basePath: "project/2026",
+                createdAt: "2026-04-22T00:00:00Z",
+                startedAt: null,
+                updatedAt: "2026-04-22T00:00:00Z",
+                parentBatchJobId: "parent-batch-001",
+              },
+            ],
+          },
+        });
+
+      const result = await query.listChildBatches("parent-batch-001");
+      expect(result).toHaveLength(1);
+      expect(result[0].batchJobId).toBe("child-001");
+      expect(result[0].parentBatchJobId).toBe("parent-batch-001");
+      expect(mockSend).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/lambda/api/lib/batch-query.ts
+++ b/lambda/api/lib/batch-query.ts
@@ -1,9 +1,27 @@
-import { QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { BatchGetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import type { BatchStatus } from "../schemas";
 import type { BatchMeta, BatchWithFiles, FileItem } from "./batch-store";
 import { BATCH_LIST_LIMIT, QUERY_LIMIT } from "./batch-store";
 import { docClient } from "./dynamodb";
 import { decodeBatchCursor, encodeBatchCursor } from "./validate";
+
+/**
+ * Raw DDB META アイテム (docClient unmarshalled) から型付き ``BatchMeta`` を
+ * 抽出する。``listBatchesByStatus`` (GSI1 経由) と ``listChildBatches``
+ * (GSI2 経由) で共有する。
+ */
+function metaItemToBatchMeta(i: Record<string, unknown>): BatchMeta {
+  return {
+    batchJobId: i.batchJobId as string,
+    status: i.status as BatchStatus,
+    totals: i.totals as BatchMeta["totals"],
+    basePath: i.basePath as string,
+    createdAt: i.createdAt as string,
+    startedAt: (i.startedAt as string | null) ?? null,
+    updatedAt: i.updatedAt as string,
+    parentBatchJobId: (i.parentBatchJobId as string | null) ?? null,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // BatchQuery — 読み取り専用クラス
@@ -95,6 +113,41 @@ export class BatchQuery {
   }
 
   // -------------------------------------------------------------------------
+  // fetchMetasByKeys — GSI1/GSI2 Query の戻り keys から BatchGetItem で本体解決
+  //
+  // ``processing-stack.ts`` の GSI1/GSI2 は ``projectionType: KEYS_ONLY`` で、
+  // Query レスポンスは PK/SK (+ GSI*PK / GSI*SK) のみを返す。
+  // ``batchJobId`` / ``status`` / ``totals`` 等の META 属性を解決するには
+  // ``BatchGetItem`` で base table を引き直す必要がある。
+  //
+  // BATCH_LIST_LIMIT <= 50 <= BatchGetItem 上限 100 key/call のため常に 1 回で完了。
+  // GSI の結果順序は BatchGetItem の結果順序と必ずしも一致しないため、
+  // 最後に PK で戻って GSI の順序を保つ。
+  // -------------------------------------------------------------------------
+  private async fetchMetasByKeys(
+    keys: Array<{ PK: string; SK: string }>,
+  ): Promise<BatchMeta[]> {
+    if (keys.length === 0) return [];
+    const res = await docClient.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [this.tableName]: { Keys: keys },
+        },
+      }),
+    );
+    const responses = (res.Responses?.[this.tableName] ?? []) as Array<
+      Record<string, unknown>
+    >;
+    // BatchGetItem の返却順は保証されないため、入力 keys の PK 順で並べ直す
+    const byPk = new Map<string, Record<string, unknown>>();
+    for (const r of responses) byPk.set(r.PK as string, r);
+    return keys
+      .map((k) => byPk.get(k.PK))
+      .filter((r): r is Record<string, unknown> => r !== undefined)
+      .map(metaItemToBatchMeta);
+  }
+
+  // -------------------------------------------------------------------------
   // listBatchesByStatus — GSI1 を使ったページング
   // -------------------------------------------------------------------------
   async listBatchesByStatus(
@@ -117,16 +170,11 @@ export class BatchQuery {
       }),
     );
 
-    const items: BatchMeta[] = (res.Items ?? []).map((i) => ({
-      batchJobId: i.batchJobId as string,
-      status: i.status as BatchStatus,
-      totals: i.totals as BatchMeta["totals"],
-      basePath: i.basePath as string,
-      createdAt: i.createdAt as string,
-      startedAt: (i.startedAt as string | null) ?? null,
-      updatedAt: i.updatedAt as string,
-      parentBatchJobId: (i.parentBatchJobId as string | null) ?? null,
+    const keys = (res.Items ?? []).map((i) => ({
+      PK: i.PK as string,
+      SK: i.SK as string,
     }));
+    const items = await this.fetchMetasByKeys(keys);
 
     const nextCursor = res.LastEvaluatedKey
       ? encodeBatchCursor(res.LastEvaluatedKey as Record<string, unknown>)
@@ -154,15 +202,10 @@ export class BatchQuery {
       }),
     );
 
-    return (res.Items ?? []).map((i) => ({
-      batchJobId: i.batchJobId as string,
-      status: i.status as BatchStatus,
-      totals: i.totals as BatchMeta["totals"],
-      basePath: i.basePath as string,
-      createdAt: i.createdAt as string,
-      startedAt: (i.startedAt as string | null) ?? null,
-      updatedAt: i.updatedAt as string,
-      parentBatchJobId: parentBatchJobId,
+    const keys = (res.Items ?? []).map((i) => ({
+      PK: i.PK as string,
+      SK: i.SK as string,
     }));
+    return this.fetchMetasByKeys(keys);
   }
 }

--- a/lib/api-stack.ts
+++ b/lib/api-stack.ts
@@ -88,11 +88,14 @@ export class ApiStack extends Stack {
 
     // BatchTable: META/FILE アイテムの CRUD + GSI1/GSI2 の Query + 反解析時の
     // 原子的コピーに必要な TransactWriteItems。
+    // ``BatchGetItem`` は GSI1/GSI2 が KEYS_ONLY projection のため、Query の
+    // 返り keys から META 本体を引き直すのに必要 (``BatchQuery.fetchMetasByKeys``)。
     fn.addToRolePolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         actions: [
           "dynamodb:GetItem",
+          "dynamodb:BatchGetItem",
           "dynamodb:PutItem",
           "dynamodb:UpdateItem",
           "dynamodb:Query",

--- a/test/api-stack.test.ts
+++ b/test/api-stack.test.ts
@@ -363,12 +363,14 @@ describe("ApiStack (batch-first IAM / env wiring, Task 6.2)", () => {
       expect(JSON.stringify(s3Resources)).toContain("batches/*");
     });
 
-    it("BatchTable への PutItem / UpdateItem / GetItem / Query / TransactWriteItems 権限を付与している", () => {
+    it("BatchTable への PutItem / UpdateItem / GetItem / BatchGetItem / Query / TransactWriteItems 権限を付与している", () => {
       const { template } = createStack();
       const stmts = extractStatements(template);
       expect(hasAction(stmts, "dynamodb:PutItem")).toBe(true);
       expect(hasAction(stmts, "dynamodb:UpdateItem")).toBe(true);
       expect(hasAction(stmts, "dynamodb:GetItem")).toBe(true);
+      // GSI KEYS_ONLY の返却 keys から META 本体を BatchGetItem で引き直す
+      expect(hasAction(stmts, "dynamodb:BatchGetItem")).toBe(true);
       expect(hasAction(stmts, "dynamodb:Query")).toBe(true);
       expect(hasAction(stmts, "dynamodb:TransactWriteItems")).toBe(true);
     });


### PR DESCRIPTION
# Summary

``GET /batches?status=X`` が本番で ``items[].batchJobId`` / ``status`` / ``totals`` / ``basePath`` / ``createdAt`` / ``updatedAt`` をすべて欠落させ、``startedAt`` / ``parentBatchJobId`` のみ null で返す **長年の既存バグ** を修正する。agent 自律実行で一覧取得して個別バッチに辿れない問題を解消。

## Related

- Spec: なし (dead-code 既存バグ、Path B 直接実装)
- 発見経緯: `ed348db` 以降の Swagger 改善デプロイ後に実 API を叩いて判明。直前 commit とは**無関係の既存バグ**と確定済。

## 原因のフルチェーン

1. `lib/processing-stack.ts:116-128` で GSI1 / GSI2 はコスト削減のため意図的に ``projectionType: KEYS_ONLY``。
2. GSI Query レスポンスは PK / SK / GSI*PK / GSI*SK のみで、META 属性は含まれない。
3. `lib/batch-query.ts::listBatchesByStatus` は属性全 projection を前提に ``i.batchJobId as string`` を盲目マップ。→ `undefined`。
4. `startedAt` / `parentBatchJobId` は ``?? null`` で `undefined → null` に救われ、他は `JSON.stringify` で drop される。

## 修正

1+1 fetch パターン:
- GSI Query で PK/SK を取得 → `BatchGetItem` で base table から META を一括取得
- `BATCH_LIST_LIMIT = 50` ≤ BatchGetItem 上限 100 key/call のため常に 1 回で完了
- BatchGetItem の戻り順は保証されないので、GSI の順序を保つよう入力 keys 順で並べ替え
- `listChildBatches` (GSI2、現在 dead code) にも同じ bug があるため同時修正
- 共通 helper (`metaItemToBatchMeta` + private `fetchMetasByKeys`) にマッピング / フェッチを集約

**IAM 追加**: `ApiStack` Lambda ロールに `dynamodb:BatchGetItem` を追加 (初回デプロイで AccessDenied による 500 regression が発生したため追加コミット `889fba2` で修正済み)。

## Verification

ローカル:
- [x] ``pnpm --filter yomitoku-api test``: 121/121 pass (+3 new)
- [x] ``pnpm test``: root 226/226 pass (+1 BatchGetItem IAM assertion)
- [x] ``pnpm lint``: biome + check-legacy-refs + typecheck:test clean
- [x] ``pnpm build``: clean

本番 (ap-northeast-1):
- [x] ``cdk deploy ApiStack`` が ``UPDATE_COMPLETE``
- [x] ``curl .../batches?status=COMPLETED`` が ``batchJobId`` / ``status`` / ``totals`` 等を含む完全な BatchDetail オブジェクトを返却確認

## SageMaker Async 移行エビデンス

本 PR はインフラ系スタックに触れず ``lambda/api/`` と ``lib/api-stack.ts`` の IAM 1 箇所のみ変更。Runbook 照合:
- [x] ``docs/runbooks/sagemaker-async-cutover.md`` の Step 5 (ApiStack デプロイ) に準拠した範囲内
- [x] ロールバック可: 前 revision (``276cbfe``) に戻すだけで復元可能
- [x] 破壊的変更なし (``BatchTable`` / Endpoint / ControlTable 契約に影響なし)

## Test Plan

- [x] 既存 unit test ``batch-query.test.ts`` に KEYS_ONLY シナリオ 2 件、BatchGetItem を呼ばない空シナリオ 1 件を追加
- [x] ``api-stack.test.ts`` の IAM allowlist に ``BatchGetItem`` を追加
- [x] 本番 ``curl`` で実応答の構造を確認

## Notes

同時に発見された関連課題 (本 PR 外):
- **orphan PROCESSING 5 件 / FAILED 2 件**: 過去の E2E 試行で終端されなかった古い META アイテム。別 PR (クリーンアップスクリプト) で処理予定。
- **テスト空洞**: GSI Query の keys-only 返却を mock が再現していなかった。本 PR で追加の KEYS_ONLY テストが将来の類似 regression を防ぐ。
- **`listChildBatches` は route 未配線**: 将来 `/batches/{id}/children` 等を作る場合に本修正が効く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)