### PR TITLE
feat(result-filename-extension-preservation): メイン JSON 命名規約を {原本ファイル名}.json に変更

### DIFF
--- a/.kiro/specs/result-filename-extension-preservation/design.md
+++ b/.kiro/specs/result-filename-extension-preservation/design.md
@@ -1,0 +1,553 @@
+# Technical Design
+
+## Overview
+
+**Purpose**: 本機能はメイン OCR JSON の S3 オブジェクトキーから原本ドキュメントの形式を機械的に判別できるようにし、複数フォーマット (PDF / PPTX / DOCX / XLSX) を扱う API consumer に対して `BatchFile.resultKey` の自己記述性を確保する。
+
+**Users**: バッチ API consumer (監査用途で原本と OCR 結果を機械的に突合する後段処理) と、複数フォーマット混在バッチを投入するユーザーが対象。
+
+**Impact**: 既存の `BatchFile.resultKey` 値フォーマット (`batches/{id}/output/{stem}.json`) を `batches/{id}/output/{原本ファイル名}.json` (例: `report.pdf.json` / `deck.pptx.json`) に変更する破壊的変更。後方互換は OpenAPI description で migration ノートを明示することで担保する。既存バッチ (実行中 / 過去分) の遡及リネームは行わない。
+
+### Goals
+
+- メイン OCR JSON の S3 命名規約を `{原本ファイル名}.json` に統一し、`BatchFile.resultKey` 値だけで原本拡張子を判別可能にする
+- Office 形式 (`deck.pptx`) は Fargate 内で変換後 PDF (`deck.pdf`) を経由するが、JSON 命名は変換前の原本 Office 名 (`deck.pptx`) を使用する
+- 可視化処理 (`generate_all_visualizations`) を新命名規約に追従させ、PDF / Office 形式の双方で正しく PDF を解決する
+- OpenAPI description で `BatchFile.resultKey` の値フォーマット変更と移行ノートを明示する
+
+### Non-Goals
+
+- 追加フォーマット (`.md` / `.csv` / `.html`) の命名統一 (yomitoku-client 側責務、将来 spec)
+- 可視化 JPEG (`{basename}_{mode}_page_{idx}.jpg`) の命名変更 (現状維持)
+- 既存バッチ (実行中 / 過去分) の S3 オブジェクト遡及リネーム / DynamoDB `resultKey` 値の遡及更新
+- DynamoDB FILE アイテムの `resultKey` 属性名変更 (値フォーマットのみ変更)
+- 新 API バージョン番号の発行 / `/v2/batches` などのパス分離
+- Feature flag / dual-write 等の段階的移行機構の導入 (hard cutover を採用)
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- メイン OCR JSON の S3 オブジェクト命名規約 (`{原本ファイル名}.json`)
+- `lambda/batch-runner/async_invoker.py` の JSON persist パスの組み立てロジック
+- `lambda/batch-runner/runner.py` の可視化 lookup における JSON → ローカル PDF 解決ロジック
+- `lambda/batch-runner/main.py` から下流モジュールへの「ローカル basename → 原本ファイル名」マッピングの伝播
+- `lambda/api/schemas.ts` の `BatchFile.resultKey` の OpenAPI description (フォーマット仕様 + 移行ノート + 追加フォーマットとの非対称メモ)
+
+### Out of Boundary
+
+- API レイヤの入力ファイル名サニタイズ規則 (本 spec ではサニタイズ済の filename をそのまま使う前提)
+- yomitoku-client が SageMaker コンテナ内で生成する追加フォーマット (`.md` / `.csv` / `.html`) の命名
+- `s3_sync.py` の `_EXT_TO_CATEGORY` 分類ロジック (拡張子末尾分類なので `.pdf.json` → `output` カテゴリへ正しく振られる)
+- `apply_process_log` の `converted_filename_map` 経由の DDB FILE PK lookup ロジック (`office-format-ingestion` で完結)
+- 可視化 JPEG ファイルの命名 (現行 `{stem}_{mode}_page_{idx}.jpg` を維持)
+- 既存バッチの S3 オブジェクト / DDB レコードの遡及移行 (運用判断で `R5.3` の通り将来 spec として独立)
+
+### Allowed Dependencies
+
+- **Upstream**: `office-format-ingestion` で導入された以下の機構を再利用する
+  - `office_converter.ConvertResult` および `ConvertedFile(original_path, pdf_path)` 型 (immutable dataclass)
+  - `main.py:201-221` の `pdf_to_original: dict[str, str]` 構築ロジック (本 spec で逆向き map も併設)
+  - `apply_process_log(..., converted_filename_map=...)` (DDB PK lookup 用、本 spec で挙動変更なし)
+- **Stack-internal**: `lambda/batch-runner/{async_invoker,runner,main}.py` 間の関数引数追加に閉じる。新規モジュール導入なし
+- **依存方向**: `office_converter` → `{async_invoker, runner.py}` ← `main.py` ← (Step Functions invoke)。`main.py` のみがマッピングを所有し、他モジュールは引数で受け取る (純粋関数原則 / 副作用なし)
+
+### Revalidation Triggers
+
+以下の変更が発生した場合、依存仕様および consumer は再検証が必要:
+
+- `BatchFile.resultKey` の値フォーマットの再変更 (OpenAPI description の改訂が伴う)
+- `office_converter.ConvertResult` または `ConvertedFile` 構造の変更 (本 spec が直接消費)
+- `apply_process_log` の `converted_filename_map` 引数仕様の変更 (本 spec の前提が崩れる)
+- API レイヤのファイル名サニタイズ規則の変更 (`BatchFile.filename` と `resultKey` のファイル名部分の一致が崩れる)
+- 追加フォーマット (`.md` / `.csv` / `.html`) の命名統一を行う将来 spec が走った場合 (本 spec の OpenAPI 非対称メモを更新する必要)
+
+## Architecture
+
+### Existing Architecture Analysis
+
+**現行フロー** (Office 形式混在の場合):
+
+1. `main.py` が `s3_sync.download_inputs` で S3 → ローカル `input_dir` にダウンロード
+2. Office 形式が含まれていれば `office_converter.convert_office_files` で `.pptx/.docx/.xlsx → .pdf` 変換 (原本 Office はローカル削除、変換後 PDF が `input_dir` に残る)
+3. `main.py:201-221` で `pdf_to_original = {converted_pdf.name: original_office.name}` を構築
+4. `run_async_batch(input_dir, output_dir, ...)` が `input_dir` の PDF を SageMaker Async に投げる
+5. `async_invoker._drain_queue` が成功通知を受け、`output_dir / f"{file_stem}.json"` に保存 (**本 spec の改修対象**)
+6. `runner.generate_all_visualizations(input_dir, output_dir)` が `output_dir/*.json` を `json_file.stem → input_dir/{basename}.pdf` で逆引き (**本 spec の改修対象**)
+7. `main.py` が `apply_process_log(..., converted_filename_map=pdf_to_original)` を実行し、DDB FILE PK は原本 Office 名で書き戻し (現行で正しく動作)
+8. `s3_sync.upload_outputs` が `output_dir/*` を拡張子末尾で分類してアップロード (`*.json → output/`)
+
+**現状の制約**:
+
+- `pdf_to_original` は `apply_process_log` にしか渡されておらず、`async_invoker` および `runner` は「ローカル basename = 原本ファイル名」前提で動作している
+- `async_invoker.py:362, 492` は `file_path.stem` (拡張子なし) を JSON 命名に使用しているため、PDF 入力でも `report.pdf → report.json` となり、原本拡張子が失われる
+- `runner.py:170-171` は `json_file.stem` から `.pdf` を 1 段だけ剥がす前提で逆引きしている (新仕様 `deck.pptx.json` では `stem = deck.pptx` となり破綻)
+
+### Architecture Pattern & Boundary Map
+
+**Selected pattern**: 既存の純粋関数 + データフロー注入 (steering 規約)。新規モジュールは追加せず、既存関数のシグネチャに `dict[str, str]` 型のマッピング引数を追加する。`main.py` がオーケストレータとしてマッピングを所有し、下流モジュールは引数で受け取る。
+
+```mermaid
+graph TB
+    subgraph BatchRunner [lambda/batch-runner]
+        Main[main.py orchestrator]
+        OfficeConv[office_converter.convert_office_files]
+        Async[async_invoker.run_async_batch]
+        Runner[runner.generate_all_visualizations]
+        Apply[batch_store.apply_process_log]
+    end
+
+    subgraph Maps [Filename Maps owned by main.py]
+        L2O[local_to_original<br/>deck_pdf to deck_pptx]
+        O2L[original_to_local<br/>deck_pptx to deck_pdf]
+    end
+
+    subgraph DataLayer [Data Layer]
+        DDB[(DynamoDB BatchTable)]
+        S3Out[(S3 batches/id/output/)]
+    end
+
+    OfficeConv --> Main
+    Main --> L2O
+    Main --> O2L
+    L2O --> Async
+    L2O --> Apply
+    O2L --> Runner
+    Async --> S3Out
+    Apply --> DDB
+```
+
+**Architecture Integration**:
+
+- **Domain/feature boundaries**: `main.py` がフィルナムマッピングを所有。`async_invoker` / `runner` は引数で受け取って動作する純粋関数 (steering 規約「main.py 以外のモジュールは副作用を持たない純粋関数」を維持)
+- **Existing patterns preserved**: `office-format-ingestion` で導入した `pdf_to_original` の片方向マップを `local_to_original` として継承。本 spec で逆向き `original_to_local` を併設するのみ
+- **New components rationale**: 新規 component は導入しない。既存 4 モジュール (`main`, `async_invoker`, `runner`, `schemas.ts`) のシグネチャ拡張に閉じる
+- **Steering compliance**:
+  - `tech.md`: Python yomitoku-client / Async Invoker パターンを維持。`@dataclass(frozen=True)` 不採用は変更データが単純な `dict[str, str]` 1 つで済むため (YAGNI)
+  - `structure.md`: `main.py` 以外のモジュールに副作用を持たせない原則に従い、マッピングは引数で渡す。新ファイル追加なし
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Backend / Services | Python 3.12 | `async_invoker.py` / `runner.py` / `main.py` の引数追加と命名ロジック改修 | 新規依存追加なし |
+| Backend / Services | TypeScript 5.9.x + Hono 4.x + @hono/zod-openapi 1.x | `schemas.ts` の `BatchFile.resultKey` description 改修 | 新規依存追加なし |
+| Data / Storage | DynamoDB BatchTable (既存) | `resultKey` 属性値フォーマット変更のみ (属性名 / GSI / TTL は変更なし) | スキーマ変更なし |
+| Data / Storage | S3 BatchBucket (既存) | メイン JSON のキー命名規約変更 | 既存オブジェクトは遡及リネームしない |
+| Testing | pytest + moto + Stubber / Vitest | 既存 fixture 約 22 箇所の書換 + Office 形式の新規 test case 追加 | 新規依存追加なし |
+
+## File Structure Plan
+
+### Modified Files
+
+#### Python (Batch Runner)
+
+- `lambda/batch-runner/async_invoker.py` — `run_async_batch` 関数および `AsyncInvoker` クラスに `local_to_original: dict[str, str]` 引数を追加。`_drain_queue` 内の `persisted_path = output_dir / f"{file_stem}.json"` (L492) を `output_dir / f"{output_filename}.json"` に変更。`output_filename = local_to_original.get(file_path.name, file_path.name)` で解決 (Office case のみ map に entry あり、PDF case は identity)
+- `lambda/batch-runner/runner.py` — `generate_all_visualizations` に `original_to_local: dict[str, str] | None` 引数を追加。L169-173 の lookup ロジックを以下に書き換え:
+  - `original_input_name = json_file.name[:-len(".json")]` で `.json` を 1 段剥がす
+  - `local_pdf_basename = original_to_local.get(original_input_name, original_input_name)` (Office case 以外は identity → ファイル名そのまま)
+  - `pdf_path = in_path / local_pdf_basename`
+  - lookup 失敗時は `errors_per_file` に `"local PDF not found: {local_pdf_basename}"` を記録 (既存と同等の silent skip + warning)
+- `lambda/batch-runner/main.py` — L201-221 の既存 `pdf_to_original` を `local_to_original` にリネーム (役割と一致)。新規に `original_to_local: dict[str, str]` を併設して構築。`run_async_batch(...)` 呼び出し L230-238 と `generate_all_visualizations(...)` 呼び出し L251-254 にそれぞれ map 引数を追加。既存の `apply_process_log(..., converted_filename_map=local_to_original)` への引数渡しは継続 (引数名 `converted_filename_map` はそのまま、value は `local_to_original` を流用)
+
+#### TypeScript (API)
+
+- `lambda/api/schemas.ts` — `BatchFile.resultKey` (L367-371) の OpenAPI description を以下に書き換え:
+  - 値フォーマット: `batches/{batchJobId}/output/{原本ファイル名}.json` (`{原本ファイル名}` は `BatchFile.filename` と一致、原本拡張子を含む)
+  - 例: `report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`
+  - 移行ノート: 旧フォーマットは `{stem}.json` であったこと、`.json` 直前のファイル名部分に拡張子が含まれるよう変更されたこと、既存 consumer の basename 抽出処理 (`.json` 1 段剥がし前提) に影響すること
+  - 追加フォーマット非対称メモ: yomitoku-client が出力する `.md` / `.csv` / `.html` は本 spec の対象外で、命名は `{stem}_{ext}.json` (yomitoku-client 規約) のまま。将来 spec で統一の可能性あり
+  - `example` 値も `batches/abc-123/output/document.pdf.json` に更新
+
+#### Tests
+
+- `lambda/batch-runner/tests/test_async_invoker.py` — L955 等で persist 後のファイル名 assert を `{name}.json` 形式に書き換え。Office 形式 (`deck.pptx.json` 期待) の test case を追加
+- `lambda/batch-runner/tests/test_runner.py` — `generate_all_visualizations` の lookup test に `original_to_local` 経由 / 経由なしの両ケースを追加
+- `lambda/batch-runner/tests/test_run_async_batch_e2e.py` — L252, L784 等の assert を新フォーマットに書換 (`/ok.json` → `/ok.pdf.json`、`/deck.json` → `/deck.pptx.json`)
+- `lambda/batch-runner/tests/test_main.py` — L758, L830, L960 等の fixture と assert を新フォーマットに書換
+- `lambda/batch-runner/tests/test_batch_store.py` — `output_path` / `resultKey` 関連の fixture を新フォーマットに書換 (L116, L313, L322, L335, L373, L435, L483, L515, L557, L564)
+- `lambda/api/__tests__/lib/batch-presign.test.ts`, `batch-store.test.ts`, `routes/batches.test.ts` — `resultKey` 値の fixture を新フォーマットに書換 (L220, L175, L243, L116)
+- `lambda/api/__tests__/openapi-description.test.ts` — `BatchFile.resultKey` description に新フォーマット明示と移行ノートが含まれることを assert する新規テストケース追加
+
+> 既存テスト規約 (`structure.md` の 1:1 対応原則) を維持。新規テストファイルは作成しない (既存ファイルへの追加で完結)。
+
+## System Flows
+
+### Filename Mapping Construction & Propagation
+
+```mermaid
+sequenceDiagram
+    participant Main as main.py
+    participant Conv as office_converter
+    participant Async as async_invoker.run_async_batch
+    participant Runner as runner.generate_all_visualizations
+    participant Apply as batch_store.apply_process_log
+    participant DDB as DynamoDB
+    participant S3 as S3 output/
+
+    Main->>Conv: convert_office_files(input_dir)
+    Conv-->>Main: ConvertResult{succeeded=[ConvertedFile(orig, pdf)], failed=[...]}
+    Note over Main: local_to_original = {pdf.name: orig.name}<br/>original_to_local = {orig.name: pdf.name}
+
+    Main->>Async: run_async_batch(input_dir, output_dir, local_to_original=...)
+    Note over Async: 各 file_path について<br/>output_filename = local_to_original.get(file_path.name, file_path.name)<br/>persist_path = output_dir / output_filename + ".json"
+    Async->>S3: upload to batches/id/output/{name}.json (via upload_outputs 経由)
+
+    Main->>Runner: generate_all_visualizations(input_dir, output_dir, original_to_local=...)
+    Note over Runner: 各 json_file について<br/>orig_name = json_file.name[:-len(.json)]<br/>local_pdf = original_to_local.get(orig_name, orig_name)<br/>pdf_path = input_dir / local_pdf
+
+    Main->>Apply: apply_process_log(..., converted_filename_map=local_to_original)
+    Apply->>DDB: UpdateItem FILE.resultKey = batches/id/output/{name}.json
+```
+
+**Key Decisions**:
+
+- **PDF identity case**: native PDF 入力では `local_to_original` および `original_to_local` に entry が無く、`dict.get(key, key)` で identity が返る。実装簡素化のため。
+- **Office case**: `convert_office_files` の戻り値から両方向 map を組み立てる。逆引きが必要なのは `runner.py` のみだが、実装明示性のため両方向を `main.py` で構築する。
+- **Failure path**: 変換失敗 / OCR 失敗時は `output_path` が `None` のまま `_append_log_entry` され、`apply_process_log` 経由でも `result_key` は書き込まれない (既存挙動を維持)。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces / Files | Flows |
+|-------------|---------|------------|--------------------|-------|
+| 1.1 | PDF `report.pdf` → `report.pdf.json` | `async_invoker.AsyncInvoker._drain_queue` | `async_invoker.py` L492, `run_async_batch` 引数追加 | Mapping Propagation |
+| 1.2 | PPTX `deck.pptx` → `deck.pptx.json` (変換後 PDF 名でなく原本 Office 名) | `main.py` (map 構築) + `async_invoker._drain_queue` | `main.py` L201-238, `async_invoker.py` L492 | Mapping Propagation |
+| 1.3 | DOCX/XLSX 同様 | 同 1.2 | 同 1.2 | Mapping Propagation |
+| 1.4 | 非 ASCII / サニタイズ済 filename を JSON 命名に使用 | `async_invoker._drain_queue` (依存: API sanitize → DDB filename → local file 名の同一性) | `async_invoker.py` L492 | Mapping Propagation |
+| 1.5 | API レスポンス `BatchFile.resultKey` 値が `{原本ファイル名}.json` 終端 | `apply_process_log` (entry.output_path 自動追従) + API 経路 | `batch_store.py` L297-299 (変更なし), `batch-query.ts` L81 (変更なし) | Mapping Propagation |
+| 2.1 | PDF 可視化 `report_{mode}_page_{idx}.jpg` | `runner._generate_for_single_file` | `runner.py` L136-148 (変更なし) | — |
+| 2.2 | PPTX 可視化 `deck_{mode}_page_{idx}.jpg` | `runner.generate_all_visualizations` (lookup logic) | `runner.py` L154-187 (lookup 改修) | Mapping Propagation |
+| 2.3 | PDF / Office 双方で PDF 解決成功 | `runner.generate_all_visualizations` | `runner.py` L169-173 | Mapping Propagation |
+| 2.4 | 可視化 JPEG 命名据え置き (`{basename}_{mode}_page_{idx}.jpg`) | `runner._generate_for_single_file` | `runner.py` L136-148 (変更なし) | — |
+| 3.1 | 変換失敗 → `errorCategory=CONVERSION_FAILED` + no resultKey | `_append_conversion_failures_to_log` + `apply_process_log` (既存) | `main.py` L227, `batch_store.py` (変更なし) | — |
+| 3.2 | OCR 失敗 → `errorCategory=OCR_FAILED` + no resultKey | `apply_process_log` (既存) | `batch_store.py` (変更なし) | — |
+| 3.3 | PENDING/PROCESSING 中は `resultKey` 未返却 | API consumer は条件付き取得 (既存) | `batch-query.ts` (変更なし) | — |
+| 4.1 | OpenAPI で新フォーマット仕様明示 | `BatchFile.resultKey` schema | `schemas.ts` L367-371 | — |
+| 4.2 | 移行ノートを description に含める | 同 4.1 | 同 4.1 | — |
+| 4.3 | `resultKey` 属性名 / `.json` 終端不変 | `BatchFile.resultKey` schema | `schemas.ts` L367-371 | — |
+| 4.4 | 追加フォーマットとの非対称メモ | 同 4.1 | 同 4.1 | — |
+| 5.1 | S3 既存オブジェクト遡及リネームなし | (実装なし — migration script を追加しない方針) | — | — |
+| 5.2 | DDB `resultKey` 既存値遡及更新なし | 同 5.1 | — | — |
+| 5.3 | デプロイ後の新規バッチのみ新仕様 | Fargate task 単位でのコンテナ画像更新 (in-flight 影響なし) | (デプロイ手順) | — |
+
+## Components and Interfaces
+
+| Component | Domain/Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|--------------|--------|--------------|------------------|-----------|
+| `main.py` orchestrator | Batch Runner / Orchestrator | フィルナムマッピングを所有し、下流モジュールに pipe through | 1.2, 1.3, 2.2, 2.3 | `office_converter` (P0), `async_invoker` (P0), `runner` (P0), `batch_store` (P1) | Service |
+| `async_invoker.AsyncInvoker` | Batch Runner / Service | SageMaker Async invoke と JSON persist 命名 | 1.1, 1.2, 1.3, 1.4 | SageMaker SDK (P0), S3 SDK (P0) | Service, Batch |
+| `runner.generate_all_visualizations` | Batch Runner / Service | OCR 成功 JSON ごとに可視化 JPEG 生成 | 2.1, 2.2, 2.3 | `cv2` (P0), `pdf2image` (P0) | Service |
+| `lambda/api/schemas.ts BatchFile.resultKey` | API / Schema | OpenAPI description で新フォーマット仕様と移行ノートを明示 | 4.1, 4.2, 4.3, 4.4 | `@hono/zod-openapi` (P0) | API |
+
+### Batch Runner
+
+#### main.py orchestrator
+
+| Field | Detail |
+|-------|--------|
+| Intent | フィルナムマッピングを構築し、下流モジュール (`async_invoker` / `runner` / `apply_process_log`) に pipe through する |
+| Requirements | 1.2, 1.3, 2.2, 2.3 |
+
+**Responsibilities & Constraints**:
+
+- `office_converter.convert_office_files` の戻り値から `local_to_original: dict[str, str]` および `original_to_local: dict[str, str]` を構築 (両方向 map)
+- 既存の `pdf_to_original` 変数を `local_to_original` にリネーム (役割の明示化)。`apply_process_log(..., converted_filename_map=local_to_original)` への渡しは継続 (引数名は `converted_filename_map` のまま、value は `local_to_original` を流用)
+- `run_async_batch(...)` および `generate_all_visualizations(...)` 呼び出しに新引数を追加
+- ネイティブ PDF のみのバッチでは両 map は空 dict (`{}`) になる (`is_office_format` チェックで条件分岐済)
+
+**Dependencies**:
+
+- Inbound: Step Functions invoke (P0)
+- Outbound: `office_converter.convert_office_files` (P0), `async_invoker.run_async_batch` (P0), `runner.generate_all_visualizations` (P0), `batch_store.apply_process_log` (P1)
+- External: なし (Python stdlib のみ)
+
+**Contracts**: Service ✅
+
+##### Service Interface
+
+```python
+# main.py 内のローカル変数として保持される (公開関数なし)
+local_to_original: dict[str, str]   # {converted_pdf_basename: original_office_filename}
+original_to_local: dict[str, str]   # {original_office_filename: converted_pdf_basename}
+```
+
+- **Preconditions**: `convert_office_files` 実行後 (Office 形式が存在する場合のみ非空)
+- **Postconditions**: 両 map は互いに逆引き関係。entry 数は `convert_result.succeeded` の長さと同一
+- **Invariants**: `local_to_original` の value は API レイヤでサニタイズ済の DDB filename と一致 (`BatchFile.filename` と同値)
+
+**Implementation Notes**:
+
+- ネイティブ PDF のみのバッチ: 両 map が空 dict のまま下流に渡される。`dict.get(key, key)` 経由で identity 解決され、`{name}.json` 命名が PDF にも自動適用される
+- 変換失敗 (`ConvertFailure`): 該当ファイルは `process_log.jsonl` に `errorCategory=CONVERSION_FAILED` で書き込まれ、後段の async_invoker は呼ばれない。本 spec の命名規約変更には影響しない
+- **Drift 防止 (Single Source of Truth)**: 双方向 map を `main.py` で個別構築すると将来の保守者が片方だけ更新するリスク (`office-format-ingestion` Bug 001 と同種) があるため、以下のいずれかをタスク化して採用する:
+  - 案 A (推奨): `office_converter.py` に `build_filename_maps(convert_result: ConvertResult) -> tuple[dict[str, str], dict[str, str]]` ヘルパ関数を追加し、両 map を一箇所で原子的に構築する。`main.py` はこのヘルパを呼ぶだけ
+  - 案 B: `local_to_original` のみ `main.py` で構築し、`runner.py` 内部で `dict((v, k) for k, v in local_to_original.items())` により逆引き map を都度生成する (single source of truth、ただし `runner.py` のシグネチャ引数は `local_to_original` に統一)
+
+#### async_invoker.AsyncInvoker
+
+| Field | Detail |
+|-------|--------|
+| Intent | SageMaker Async Inference 呼び出しと、成功通知から S3 経由でダウンロードした JSON をローカルに persist する |
+| Requirements | 1.1, 1.2, 1.3, 1.4 |
+
+**Responsibilities & Constraints**:
+
+- 既存の SageMaker invoke / SQS poll / 成功失敗判定ロジックは変更なし
+- JSON persist 時のファイル名解決のみ改修: `output_filename = local_to_original.get(file_path.name, file_path.name)` で原本ファイル名を解決し、`persisted_path = output_dir / f"{output_filename}.json"` で保存
+- `local_to_original` は `run_async_batch` 関数引数として注入され、`AsyncInvoker.run_batch` 経由で `_drain_queue` に到達する
+- `_safe_ident` (SHA-1) は SageMaker `InferenceId` および S3 input key 用途のみ。ローカル JSON persist には使用しない (R1.4 担保)
+
+**Dependencies**:
+
+- Inbound: `main.py` (`run_async_batch`) (P0)
+- Outbound: SageMaker Runtime SDK (P0), S3 SDK (download) (P0)
+- External: AWS SQS Notification (Success/Failure Queue) (P0)
+
+**Contracts**: Service ✅, Batch ✅
+
+##### Service Interface
+
+```python
+async def run_async_batch(
+    *,
+    settings: BatchRunnerSettings,
+    input_dir: str,
+    output_dir: str,
+    log_path: str,
+    deadline_seconds: float,
+    local_to_original: dict[str, str] | None = None,  # 新規引数 (デフォルト空 dict 相当で None 可)
+) -> BatchResult: ...
+
+class AsyncInvoker:
+    def __init__(
+        self,
+        ...,  # 既存引数
+        local_to_original: dict[str, str] | None = None,  # 新規引数
+    ) -> None: ...
+
+    def run_batch(
+        self,
+        *,
+        input_files: list[Path],
+        output_dir: Path,
+        log_path: Path,
+        batch_job_id: str,
+        deadline_seconds: float,
+    ) -> BatchResult: ...
+    # 内部で self._local_to_original を _drain_queue に渡す
+```
+
+- **Preconditions**: `local_to_original` の key は `input_files` の各 `Path.name` と一致するものが entry として存在する (Office 形式の場合のみ)。PDF のみの場合は `None` または空 dict
+- **Postconditions**: 成功通知を受けた各ファイルは `output_dir / f"{output_filename}.json"` に保存され、`process_log.jsonl` に `output_path` 値として記録される
+- **Invariants**: `local_to_original` が `None` の場合は identity (`file_path.name → file_path.name`) と等価
+
+##### Batch Contract
+
+- **Trigger**: Step Functions → Fargate task → `main.py:main()` → `run_async_batch(...)`
+- **Input / validation**: `input_dir/*.pdf` (Office 変換後の PDF + ネイティブ PDF) と `local_to_original` map
+- **Output / destination**: `output_dir/*.json` (原本ファイル名終端) → `s3_sync.upload_outputs` 経由で `s3://bucket/batches/{id}/output/` へ
+- **Idempotency & recovery**: SageMaker InferenceId / SQS at-least-once 対応は既存ロジックを維持。本 spec の命名変更は冪等性に影響しない
+
+**Implementation Notes**:
+
+- **Integration**: `local_to_original` は `AsyncInvoker.__init__` で受け取り `self._local_to_original` に保持。`_drain_queue` 内で `local_to_original.get(file_path.name, file_path.name)` を呼ぶ。`run_async_batch` 関数経由で `AsyncInvoker` を構築する際に引数を渡す
+- **Validation**: `local_to_original` は型ヒント `dict[str, str] | None` で受ける。`None` は `{}` と同値扱い (空 dict)
+- **Risks**: `_drain_queue` 内で `file_path.name` を参照する箇所は L492 のみ (現行 `file_stem` 参照)。test_async_invoker.py で persist 後パスを assert している箇所 (L955) を新フォーマットに書換
+
+#### runner.generate_all_visualizations
+
+| Field | Detail |
+|-------|--------|
+| Intent | OCR 成功した各 JSON に対して、対応するローカル PDF を逆引きしてページ単位の可視化 JPEG を生成する |
+| Requirements | 2.1, 2.2, 2.3 |
+
+**Responsibilities & Constraints**:
+
+- 既存の `_generate_for_single_file` (`{basename}_{mode}_page_{idx}.jpg` の JPEG 出力) は変更なし (R2.4)
+- `generate_all_visualizations` の lookup ロジックを以下に書換:
+  - `original_input_name = json_file.name[:-len(".json")]` (`.json` を 1 段だけ剥がす)
+  - `local_pdf_basename = original_to_local.get(original_input_name, original_input_name)`
+  - `pdf_path = in_path / local_pdf_basename`
+- lookup 失敗時 (`pdf_path.exists()` が False) は既存と同等の `errors_per_file[basename] = [...]` 警告ログ。エラーメッセージのみ「local PDF not found: {local_pdf_basename}」に更新
+
+**Dependencies**:
+
+- Inbound: `main.py` (P0)
+- Outbound: なし (cv2 / pdf2image はファイル単位処理関数内)
+- External: `cv2` / `pdf2image` (yomitoku-client transitive 経由) (P0)
+
+**Contracts**: Service ✅
+
+##### Service Interface
+
+```python
+def generate_all_visualizations(
+    *,
+    input_dir: str,
+    output_dir: str,
+    original_to_local: dict[str, str] | None = None,  # 新規引数
+) -> dict[str, list[str]]: ...
+```
+
+- **Preconditions**: `output_dir/*.json` が存在 (`async_invoker` の persist 後)
+- **Postconditions**: 各 JSON について対応する PDF が解決できれば JPEG が生成される。解決失敗は warning ログ + 戻り値の dict に記録されるが致命ではない
+- **Invariants**: `original_to_local` が `None` の場合は identity (`json_file.name[:-5] → json_file.name[:-5]`) と等価。これは旧仕様 `{stem}.json` でも動作するが、新仕様では `report.pdf.json → report.pdf` がそのまま PDF basename に一致する
+
+**Implementation Notes**:
+
+- **Integration**: `original_to_local` は関数引数として `main.py` から注入。Default `None` で空 dict と同値
+- **Validation**: lookup 失敗は致命ではないため `errors_per_file` に記録のみ。pipeline は継続
+- **Risks**: 既存テスト `test_runner.py` の lookup test fixture を新フォーマットに更新する必要あり
+
+### API
+
+#### lambda/api/schemas.ts BatchFile.resultKey
+
+| Field | Detail |
+|-------|--------|
+| Intent | OpenAPI description で新フォーマット仕様と移行ノートを consumer に明示する |
+| Requirements | 4.1, 4.2, 4.3, 4.4 |
+
+**Responsibilities & Constraints**:
+
+- `BatchFile.resultKey` schema (`schemas.ts` L367-371) の `description` 文字列を更新
+- 値フォーマット仕様: `batches/{batchJobId}/output/{原本ファイル名}.json`
+- 移行ノート: 旧フォーマット (`{stem}.json`) からの変更点と consumer への影響
+- 追加フォーマット (`.md` / `.csv` / `.html`) との一時的非対称メモ
+- `example` プロパティを `batches/abc-123/output/document.pdf.json` に更新
+- 属性名 `resultKey` および `.json` 終端は維持 (R4.3)
+
+**Dependencies**:
+
+- Inbound: API consumer (CloudFront 経由 UI / 自動化スクリプト) (P0)
+- Outbound: なし (description は静的文字列)
+- External: `@hono/zod-openapi` (P0)
+
+**Contracts**: API ✅
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| GET | `/batches/{batchJobId}` | path: batchJobId | `BatchSummary` (含む `files[].resultKey`) | 404 (batch not found) |
+
+**Implementation Notes**:
+
+- **Integration**: `lambda/api/__tests__/openapi-description.test.ts` に `BatchFile.resultKey` description が新フォーマットと移行ノートを含むことを検証する test case を追加
+- **Validation**: `pnpm cdk synth` で OpenAPI スキーマ生成が破綻しないことを確認 (description は単なる文字列なので機械検証は不要)
+- **Risks**: description 更新のみで実装変更なし。consumer 側の migration window は本 description 更新のみで通知
+
+## Data Models
+
+### Logical Data Model
+
+本 spec で変更されるデータ要素:
+
+| 項目 | 旧 | 新 | 影響範囲 |
+|------|-----|-----|----------|
+| S3 メイン JSON キー | `batches/{id}/output/{stem}.json` | `batches/{id}/output/{原本ファイル名}.json` | S3 バケット内オブジェクト命名 |
+| DDB `FILE.resultKey` 値 | `batches/{id}/output/{stem}.json` | `batches/{id}/output/{原本ファイル名}.json` | DynamoDB BatchTable の各 FILE アイテム |
+| API レスポンス `BatchFile.resultKey` | `{stem}.json` 終端 | `{原本ファイル名}.json` 終端 | API consumer への返却値 |
+
+**Consistency**:
+
+- DDB `resultKey` の値変更と S3 オブジェクトキーは同時に新仕様化される (`apply_process_log` が両者を一括して更新する。原子性は既存ロジックで担保)
+- 既存バッチの DDB / S3 は遡及リネームしない (R5.1, R5.2)
+- 属性名 `resultKey` は不変 (R4.3)。GSI / TTL / 楽観ロックロジックも変更なし
+
+## Error Handling
+
+### Error Strategy
+
+本 spec で導入される新たな失敗モードは存在しない。既存の失敗ハンドリングを維持する:
+
+- **変換失敗 (`CONVERSION_FAILED`)**: `office_converter` で発生 → `_append_conversion_failures_to_log` でログ → `apply_process_log` で `errorCategory` 設定。`resultKey` は書き込まれない (R3.1)
+- **OCR 失敗 (`OCR_FAILED`)**: `async_invoker` で SageMaker 失敗通知を受信 → `_append_log_entry(success=False)` でログ → `apply_process_log` で `errorCategory` 設定。`resultKey` は書き込まれない (R3.2)
+- **可視化 lookup 失敗**: `runner.generate_all_visualizations` で `pdf_path.exists() == False` の場合、warning ログ + `errors_per_file` に記録のみ。バッチ全体は継続 (既存挙動を維持、R2 の妨げにはならない)
+
+### Monitoring
+
+本 spec で新規メトリクスは導入しない。既存の CloudWatch メトリクス (`FilesFailedTotal` / `BatchDurationSeconds` 等) で観測可能。
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **async_invoker JSON 命名 (R1.1)**: PDF 入力 (`report.pdf`) に対して `output_dir / "report.pdf.json"` で保存されることを assert (`test_async_invoker.py`)
+2. **async_invoker Office 命名 (R1.2, R1.3)**: `local_to_original={"deck.pdf": "deck.pptx"}` を渡した場合、`output_dir / "deck.pptx.json"` で保存されることを assert (`test_async_invoker.py` 新規ケース)
+3. **async_invoker 非 ASCII / サニタイズ済 filename (R1.4)**: API レイヤでサニタイズ済の非 ASCII filename (例: `Path("報告書.pdf")` または `_____.pdf`) を `run_async_batch` に渡した場合、persist 先パスがサニタイズ済 filename + `.json` (例: `output_dir / "報告書.pdf.json"`) と完全一致し、`_safe_ident` 由来の SHA-1 16 文字列が persist パスに **含まれない** ことを assert (`test_async_invoker.py` 新規ケース)
+4. **runner lookup 二段拡張子 (R2.2, R2.3)**: `output_dir/deck.pptx.json` と `original_to_local={"deck.pptx": "deck.pdf"}` を与えた場合、`input_dir/deck.pdf` を解決できることを assert (`test_runner.py` 新規ケース)
+5. **runner lookup ネイティブ PDF (R2.1)**: `output_dir/report.pdf.json` と空 `original_to_local` の場合、`input_dir/report.pdf` を解決できることを assert (`test_runner.py`)
+6. **schemas.ts description (R4.1, R4.2, R4.4)**: `BatchFile.resultKey` description が「`{原本ファイル名}.json`」「移行ノート」「追加フォーマット非対称」を含むことを assert (`openapi-description.test.ts` 新規ケース)
+7. **filename map drift 防止 (R1.2, R1.3, R2.2, R2.3)**: `build_filename_maps(convert_result)` ヘルパ (案 A 採用時) が同一 `convert_result` から構築した両 map が完全な逆引き関係 (`local_to_original[v] == k for k, v in original_to_local.items()`) であることを assert (`test_office_converter.py` 新規ケース)。案 B 採用時は `runner.py` 内部の逆引き構築ロジックを単体テストでカバー
+
+### Integration Tests
+
+1. **batch_store apply_process_log (R1.5, R3.1, R3.2)**: `entry.output_path = "/tmp/output/deck.pptx.json"` および `converted_filename_map={"deck.pdf": "deck.pptx"}` で実行した場合、DDB FILE PK が `deck.pptx` でルックアップされ、`resultKey = batches/{id}/output/deck.pptx.json` で UpdateItem されることを assert (`test_batch_store.py` 既存ケース更新)
+2. **process_log_reader (既存非リグレッション)**: `output_path` フィールドが新フォーマット文字列でも `ProcessLogEntry` に正しくパースされることを assert
+3. **API GET /batches (R1.5, R3.3)**: DDB から `resultKey = "batches/abc/output/deck.pptx.json"` を read し、API レスポンスにそのまま返ることを assert (`batches.test.ts` 既存ケース更新)
+
+### E2E Tests
+
+1. **混在バッチ E2E (R1.1, R1.2, R2, R3.1)**: PDF 2 ファイル + PPTX 1 ファイル + (DOCX 1 ファイル + 変換失敗 PPTX 1 ファイル) の混在で `run_async_batch` → `generate_all_visualizations` → `apply_process_log` を通貫実行し、各 FILE の `resultKey` および可視化 JPEG が新規約で生成されることを assert (`test_run_async_batch_e2e.py` 既存ケース更新)
+2. **PDF のみバッチ E2E (R1.1, R5.3)**: ネイティブ PDF のみ 3 ファイル (空 `local_to_original`) で実行し、`resultKey` が `{name}.pdf.json` 形式になることを assert
+3. **OpenAPI 整合性 E2E**: `pnpm cdk synth` で OpenAPI ドキュメントが破綻なく生成され、`BatchFile.resultKey` description が新仕様文言を含むことを assert (`openapi-description.test.ts`)
+
+### Performance Tests
+
+本 spec は新規 hot path を導入しない (`dict.get` 1 回追加のみ)。Phase 5 の既存ベンチマーク非リグレッションのみ確認 (1000 ファイル混在バッチで通常範囲)。
+
+### Contract Test (Legacy Reference Guard)
+
+**Purpose**: ~22 箇所の test fixture 移行 (Modified Files > Tests 参照) が完了した後、旧フォーマット (`{stem}.json`) のリテラルや構築パターンが test コードに残存しないことを CI で機械的に保証する。`tech.md` の「契約テスト」原則 (`scripts/check-legacy-refs.sh` / `test/check-legacy-refs.test.ts`) と同パターン。
+
+**実装案**:
+
+- `scripts/check-legacy-refs.sh` を拡張、または `scripts/check-result-key-format.sh` を新設し、以下の正規表現で違反検出 → `exit 1`:
+  - `output_dir\s*/\s*f"\{(?:file_)?stem\}\.json"` — Python `f"{stem}.json"` 系の構築パターン (現在 `lambda/batch-runner/tests/test_main.py:758,960` 等に存在)
+  - `output/[a-zA-Z0-9_-]+\.json["']` — 拡張子なし basename + `.json` のリテラル (現在 `test_batch_store.py` 等に多数)
+  - 例外として `process_log.jsonl` / `_async/outputs/{uuid}.out` / `extra_formats` ({stem}_{ext}.json yomitoku-client 規約) は除外リストで弾く
+- `pnpm lint` または pytest 契約テストの一部として実行
+
+**Coverage**: R1.1, R1.2, R1.3, R1.5, R4.1 — 旧フォーマット fixture の取り残しを検出
+
+## Migration Strategy
+
+```mermaid
+flowchart TB
+    Start([Start]) --> Pre[Pre-deploy: OpenAPI doc 更新済]
+    Pre --> Build[CDK + Docker image build]
+    Build --> Deploy[CDK deploy: BatchExecutionStack]
+    Deploy --> NewBatchOnly{デプロイ後の<br/>新規バッチか?}
+    NewBatchOnly -->|Yes| NewFmt[新フォーマット {name}.json で生成]
+    NewBatchOnly -->|No, In-flight| InFlight[既存 Fargate task は旧コード継続<br/>= 旧フォーマット {stem}.json で生成]
+    InFlight --> Drain[既存 task が完了したら<br/>新規 task は新コード]
+    NewFmt --> Done([Done])
+    Drain --> Done
+```
+
+### Phase Breakdown
+
+1. **Pre-deploy**: 本 spec の全コード変更 + テスト更新を merge。OpenAPI description は merge 時点で新仕様反映 (deploy 前でも doc は最新)
+2. **Deploy**: `pnpm cdk deploy BatchExecutionStack` で Fargate TaskDefinition の Docker image を新版に更新。API Lambda は同時 deploy
+3. **Cutover**: 新 deploy 後に開始される batch (Step Functions Execution) は新 image を pull → 新仕様で動作
+4. **In-flight handling**: deploy 瞬間に `RUNNING` 状態の Fargate task は **旧 image で走り続ける** (Fargate task は image を起動時に pull してメモリ常駐するため、deploy 中 task の動作は影響を受けない)。In-flight task が完了するまでは旧フォーマットで JSON が生成され、その後の新規 batch のみ新フォーマット
+5. **Validation**: deploy 後の新規バッチで `BatchFile.resultKey` 値が `.pdf.json` / `.pptx.json` 終端であることを sample-pdf / sample-pptx で実機確認
+
+### Rollback Triggers
+
+- E2E テストでメイン JSON が S3 に保存されない / 可視化が全件失敗する
+- API 経由で取得した `resultKey` が新フォーマットと一致しない
+- consumer 側 (CloudFront UI 等) が新フォーマットの `resultKey` をパースできず 5xx を返す
+
+### Rollback Strategy
+
+- **Hard rollback**: 直前の Docker image (旧 commit) を `pnpm cdk deploy` で再 push。新 image による Fargate task が起動できる前に旧 image に戻す。新フォーマットで生成された S3 オブジェクト / DDB レコードは残存するが、機械的判別可能性が落ちるだけで API consumer のパース処理が `.json` で 1 段剥がす実装なら互換 (旧 stem ベース) として扱える
+- **No data migration**: rollback 時に S3 / DDB の遡及書換は行わない (forward-only migration)
+- **Boundary**: rollback 後の整合性 (新旧フォーマット混在期間) は API consumer 側で `.json` 終端チェック + 拡張子部位の有無で判別可能
+
+### Validation Checkpoints
+
+- ✅ Deploy 直後: sample-pdf 1 ファイルで `resultKey = batches/{id}/output/{name}.pdf.json` を確認
+- ✅ Deploy 後 30 分: sample-pdf + sample-pptx 混在バッチで両形式の resultKey を確認
+- ✅ Deploy 後 24 時間: 本番バッチの `resultKey` 値を Spot check し、新フォーマット定着を確認

--- a/.kiro/specs/result-filename-extension-preservation/requirements.md
+++ b/.kiro/specs/result-filename-extension-preservation/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+OCR バッチ処理結果のメイン JSON ファイル名から原本ドキュメントの拡張子が剥がれているため (`report.pdf` / `report.pptx` / `report.docx` / `report.xlsx` がいずれも `report.json` で出力される)、`office-format-ingestion` のリリースによって複数フォーマットが API で受理可能になることで、以下の問題が顕在化する:
+
+- 複数フォーマット混在バッチで、`BatchFile.resultKey` だけを見て元ドキュメントの形式を機械的に判別できない
+- 同名で拡張子だけ違うファイルが同一の resultKey で衝突する余地がある (現行 stem 一意制約で API 側で弾かれてはいるが、命名側でも判別可能性を確保したい)
+- 監査用途で原本と OCR 結果を機械的に突合する後段処理が複雑化する
+
+本 spec は、メイン OCR JSON の S3 命名規約を `{file_stem}.json` から `{原本ファイル名}.json` (例: `report.pdf.json` / `deck.pptx.json`) に変更し、可視化 lookup と既存テスト fixture を新規約に追従させる。`BatchFile.resultKey` は既存 API consumer に対する破壊的変更となるため、OpenAPI description で値フォーマットの変更を明示する。
+
+## Boundary Context
+
+- **In scope**:
+  - メイン OCR JSON の S3 命名規約変更 (`{stem}.json` → `{原本ファイル名}.json`)
+  - 可視化 lookup ロジックの二段拡張子対応 (PDF / Office 形式の双方で正しく PDF を解決)
+  - Office 形式の原本ファイル名 (`deck.pptx`) を変換後 PDF (`deck.pdf`) と分離して保持する仕組み
+  - `BatchFile.resultKey` の OpenAPI description 更新と移行通知
+  - 既存テスト fixture / assertion の新規約への移行
+- **Out of scope**:
+  - 追加フォーマット (`.md` / `.csv` / `.html`) のファイル名統一 (yomitoku-client 側責務、将来 spec)
+  - 可視化 JPEG (`{basename}_{mode}_page_{idx}.jpg`) の命名変更
+  - 既存バッチ (実行中 / 過去分) の遡及リネーム / S3 オブジェクトの一括移動
+  - DynamoDB の `resultKey` 属性名の変更 (値フォーマットのみ変更)
+  - 新 API バージョン番号の発行 / `/v2/batches` などのパス分離
+- **Adjacent expectations**:
+  - `office-format-ingestion` で導入された `convert_office_files` 戻り値 (変換後 PDF と原本 Office パスのペア) と `apply_process_log` の `converted_filename_map` 機構を本 spec のスコープで再利用する
+  - 入力ファイル名に対する API レイヤのサニタイズ規則 (空白処理 / 非 ASCII 処理) は本 spec で変更しない。本 spec は「サニタイズ後の原本ファイル名」を JSON 命名に使用する
+  - yomitoku-client が SageMaker コンテナ内で生成する追加フォーマット (`.md` / `.csv` / `.html`) の命名は本 spec で変更せず、メイン JSON とのファイル名非対称が一時的に発生する
+
+## Requirements
+
+### Requirement 1: メイン OCR JSON ファイル名の拡張子保持
+
+**Objective:** API consumer として、`BatchFile.resultKey` から原本ドキュメントの形式を機械的に判別したいので、メイン OCR JSON ファイル名に原本拡張子を含めてほしい。
+
+#### Acceptance Criteria
+
+1. When 入力 `report.pdf` の OCR が成功したとき、the Batch Runner Service shall save the main OCR JSON to S3 key `batches/{batchJobId}/output/report.pdf.json`.
+2. When 入力 `deck.pptx` (Office 形式、Fargate 内で `deck.pdf` に変換) の OCR が成功したとき、the Batch Runner Service shall save the main OCR JSON to S3 key `batches/{batchJobId}/output/deck.pptx.json` (変換後 PDF の名前ではなく原本 Office 名を使用).
+3. When 入力 `report.docx` または `report.xlsx` の OCR が成功したとき、the Batch Runner Service shall save the main OCR JSON to S3 key `batches/{batchJobId}/output/report.docx.json` または `batches/{batchJobId}/output/report.xlsx.json`.
+4. When 入力ファイル名が非 ASCII 文字またはサニタイズ対象文字を含むとき、the Batch Runner Service shall ensure the resulting `resultKey` value contains exactly the same サニタイズ済の原本ファイル名が API レスポンスの `BatchFile.filename` と一致するようにし、内部的なハッシュ済識別子をファイル名に流出させない。
+5. When API consumer が `GET /batches/{batchJobId}` で対象ファイルを照会したとき、the API Service shall return `BatchFile.resultKey` の値として `batches/{batchJobId}/output/{原本ファイル名}.json` 形式の S3 キーを返す。
+
+### Requirement 2: 可視化機能の非リグレッション
+
+**Objective:** Operator として、メイン JSON 命名規約の変更によって OCR 結果の可視化 (PDF オーバーレイ JPEG) が壊れないことを保証したい。
+
+#### Acceptance Criteria
+
+1. When 入力 `report.pdf` の OCR + 可視化が完了したとき、the Batch Runner Service shall produce visualization JPEGs at `batches/{batchJobId}/visualizations/report_{mode}_page_{idx}.jpg`.
+2. When 入力 `deck.pptx` (Office 形式、Fargate 内で `deck.pdf` に変換) の OCR + 可視化が完了したとき、the Batch Runner Service shall produce visualization JPEGs at `batches/{batchJobId}/visualizations/deck_{mode}_page_{idx}.jpg`.
+3. When 可視化処理が JSON ファイルから対応する PDF (元 PDF または変換後 PDF) を逆引きするとき、the Batch Runner Service shall correctly resolve the PDF path for both PDF inputs and Office-format inputs converted to PDF, without raising file-not-found errors.
+4. The Batch Runner Service shall preserve the existing visualization JPEG naming convention (`{basename}_{mode}_page_{idx}.jpg`, where `{basename}` is the stem of the original document name).
+
+### Requirement 3: 失敗ケースとエラーカテゴリの整合
+
+**Objective:** API consumer として、変換失敗 / OCR 失敗時のレスポンスが新命名規約でも一貫していることを保証したい。
+
+#### Acceptance Criteria
+
+1. If Office 形式の入力ファイル (例: `deck.pptx`) の変換が失敗したとき、the API Service shall return `BatchFile.errorCategory = CONVERSION_FAILED` and shall not return a `BatchFile.resultKey` value for that file.
+2. If OCR 推論が失敗したとき、the API Service shall return `BatchFile.errorCategory = OCR_FAILED` and shall not return a `BatchFile.resultKey` value for that file.
+3. While ファイルが処理中 (`PENDING` / `PROCESSING`) の状態にあるとき、the API Service shall not return a `BatchFile.resultKey` value for that file.
+
+### Requirement 4: API ドキュメントと移行通知
+
+**Objective:** 既存 API consumer として、`BatchFile.resultKey` の値フォーマット変更を事前に把握し、パース処理を更新できるようにしたい。
+
+#### Acceptance Criteria
+
+1. The API Service shall update the OpenAPI description of `BatchFile.resultKey` to specify that the value now follows the format `batches/{batchJobId}/output/{原本ファイル名}.json`, where `{原本ファイル名}` retains the original file extension (例: `report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`).
+2. The API Service shall include a migration note in the OpenAPI description explaining that the `.json` 直前のファイル名部分に原本拡張子が含まれるよう変更されたこと、および既存 consumer の `resultKey` パース処理 (basename を抽出する場合) に影響することを明示する。
+3. The API Service shall preserve the `resultKey` attribute name and the invariant that the value ends with `.json` (terminating extension は変更しない).
+4. The API Service shall document in the OpenAPI description that メイン JSON と yomitoku-client が出力する追加フォーマット (`.md` / `.csv` / `.html`) の命名は一時的に非対称 (例: メイン `report.pdf.json` / 追加 `report.md`) であり、将来 spec で統一する可能性があると注記する。
+
+### Requirement 5: 既存バッチへの非影響
+
+**Objective:** 運用担当者として、本変更が既にデプロイ済の OCR バッチ (実行中 / 過去分) の S3 オブジェクトおよび DynamoDB の `resultKey` 値を破壊しないことを保証したい。
+
+#### Acceptance Criteria
+
+1. The Batch Runner Service shall not retroactively rename existing main OCR JSON objects in S3 for previously completed batches.
+2. The Batch Runner Service shall not retroactively update `resultKey` values in existing DynamoDB FILE items.
+3. When 本変更のデプロイ後に新規作成されたバッチが実行されたとき、only those new batches shall produce main JSON files following the new naming convention; in-flight バッチ (デプロイ前に開始されたが未完了のもの) の挙動は design phase で決定する。

--- a/.kiro/specs/result-filename-extension-preservation/research.md
+++ b/.kiro/specs/result-filename-extension-preservation/research.md
@@ -1,0 +1,197 @@
+# Gap Analysis: result-filename-extension-preservation
+
+## 1. Current State Investigation
+
+### 主要モジュールと現状の挙動
+
+| モジュール | 該当箇所 | 現状の挙動 |
+|---|---|---|
+| `lambda/batch-runner/async_invoker.py` | L362, L492 | `file_stem = file_path.stem` → 永続化先 `output_dir / f"{file_stem}.json"` |
+| `lambda/batch-runner/runner.py` | L170-171 | 可視化 lookup: `basename = json_file.stem` → `pdf_path = in_path / f"{basename}.pdf"` (`.json` を 1 段だけ剥がす前提) |
+| `lambda/batch-runner/office_converter.py` | L268-394 | `convert_office_files()` → `ConvertResult(succeeded=[ConvertedFile(original_path, pdf_path)], failed=[...])` を返す。原本→変換後の対応情報は既に保持 |
+| `lambda/batch-runner/main.py` | L201-221 | `pdf_to_original: dict[str, str] = {converted_pdf.name: original_office.name}` を組み立てて `apply_process_log(..., converted_filename_map=pdf_to_original)` に渡している |
+| `lambda/batch-runner/main.py` | L230-254 | `run_async_batch(input_dir, output_dir, log_path, ...)` および `generate_all_visualizations(input_dir, output_dir)` には `pdf_to_original` を渡していない (現在は basename = local file 名前提) |
+| `lambda/batch-runner/batch_store.py` | L297-299 | `result_key = f"batches/{batch_job_id}/output/{Path(entry.output_path).name}"` — `entry.output_path.name` から自動追従 |
+| `lambda/batch-runner/batch_store.py` | L236, L255-285 | `apply_process_log(..., converted_filename_map: dict[str, str] | None = None)` — Bug 001 修正で導入済 (key=converted PDF basename, value=original filename) |
+| `lambda/api/schemas.ts` | L367-371 | `resultKey: z.string().optional()` — OpenAPI description は generic、format invariant 未明示 |
+| `lambda/api/lib/batch-query.ts` | L81 | DDB から `i.resultKey as string | undefined` を read のみ。値変換なし |
+| `lambda/batch-runner/s3_sync.py` | L37-49 | `_EXT_TO_CATEGORY`: `.json → ("output", None)` / `.md, .csv, .html, .pdf → ("results", "result")` / `.jpg, .jpeg, .png → ("visualizations", "visualization")`。拡張子末尾で分類するため二段拡張子 (`.pdf.json`) でも `.json → output` に正しく振り分けられる |
+
+### Convention / Pattern の制約
+
+- **DynamoDB 双方契約**: `lambda/api/lib/batch-store.ts` と `lambda/batch-runner/batch_store.py` は同じキー/属性を読み書きする (steering の構造規約)。`resultKey` 属性名は不変。値フォーマットの変更のみ。
+- **EARS 規約 + 現行命名**: 可視化 JPEG (`{basename}_{mode}_page_{idx}.jpg`) の `{basename}` は **stem** ベース。本 spec では JSON 命名のみ変更し、JPEG 命名は据え置く (R2.4)。
+- **Async InferenceId と JSON 命名は別系統**: `_safe_ident` (SHA-1 16 文字) は SageMaker InferenceId / S3 input key 用で、ローカル JSON 保存名には適用されない (現状 `file_stem` をそのまま使用)。
+- **テスト pattern**: `lambda/batch-runner/tests/` は moto + Stubber で完結。`lambda/batch-runner/.venv` 内の `yomitoku-client` は SageMaker コンテナ側で `{stem}_{ext}.json` と命名 (追加フォーマット用) — batch-runner からは制御不可 (Out of scope)。
+
+## 2. Requirements Feasibility Analysis
+
+### Requirement → Asset Map (Gap タグ付き)
+
+| Req | 必要な変更 | 既存資産 | Gap |
+|---|---|---|---|
+| **R1.1** PDF `report.pdf` → `report.pdf.json` | `async_invoker.py:492` の命名を `f"{file_path.name}.json"` に変更 | `async_invoker.py` 内の `file_path` (`Path` オブジェクト) | **Missing** (命名規約の単純置換、追加データ不要) |
+| **R1.2** PPTX `deck.pptx` → `deck.pptx.json` | `async_invoker.py` が「ローカル PDF basename → 原本 Office basename」を解決できるように `main.py` から逆引き map を渡す | `main.py:201-221` の `pdf_to_original` (既存) | **Missing** (引数追加と pipe through。データソースは既存) |
+| **R1.3** DOCX/XLSX 同様 | R1.2 と同じ機構で対応 | 同上 | R1.2 と同時解決 |
+| **R1.4** 非 ASCII / サニタイズ | API レイヤでサニタイズ済の filename をそのまま JSON 命名に使用 | `s3_sync.py` で `download` した local file 名 = サニタイズ済 DDB filename | **Constraint** (現状の sanitize → S3 → download チェーンに依存。サニタイズ規則自体は本 spec で変更しない) |
+| **R1.5** API 経由 `resultKey` 値 | `batch_store.py:297-299` の `result_key` 組み立てが `entry.output_path.name` 自動追従 | `batch_store.apply_process_log` | **No code change** (async_invoker の命名変更が直接反映される) |
+| **R2.1** PDF 可視化 | `runner.py` の json→pdf lookup を「`.json` を 1 段剥がす」→「変換後 PDF basename を解決する」に書き換え | `runner.py:170-171` | **Missing** (lookup ロジック書き換え) |
+| **R2.2** PPTX 可視化 | 同上 + 原本→変換後 map (`{deck.pptx.json: deck.pdf}`) を渡す | `main.py` の `pdf_to_original` を逆向きに使う (`original.name → pdf.name`) | **Missing** (`main.py` から `generate_all_visualizations` への引数追加) |
+| **R2.3** 可視化 PDF 解決の一貫性 | R2.1 + R2.2 の結合 | — | R2.1/R2.2 同時解決 |
+| **R2.4** 可視化 JPEG 命名据え置き | 既存規約 (`{basename}_{mode}_page_{idx}.jpg`) を維持 | `runner.py:146` | **No code change** |
+| **R3.1** 変換失敗時 errorCategory + no resultKey | 既存 `_append_conversion_failures_to_log` + `apply_process_log` で実装済 | `main.py:227`, `batch_store.py` | **No code change** (テストで非リグレッション検証) |
+| **R3.2** OCR 失敗時 errorCategory + no resultKey | 既存挙動 (failure path で `output_path` 未設定 → resultKey 未書込) | `apply_process_log` | **No code change** (テストで非リグレッション検証) |
+| **R3.3** PENDING/PROCESSING で resultKey 無し | 既存挙動 | — | **No code change** |
+| **R4.1** OpenAPI description 更新 | `schemas.ts:367-371` の `BatchFile.resultKey` description を新フォーマットで上書き | `schemas.ts` | **Missing** (description 文字列追加) |
+| **R4.2** 移行ノート | 同上 | 同上 | **Missing** |
+| **R4.3** `.json` 終端不変 | description で明示 | 同上 | **Missing** (記述追加) |
+| **R4.4** 追加フォーマットとの非対称メモ | 同上 | 同上 | **Missing** (記述追加) |
+| **R5.1** S3 遡及リネーム無し | コードに retroactive 操作を入れない | — | **Constraint** (migration script を作らない方針を design で確定) |
+| **R5.2** DDB resultKey 遡及更新無し | 同上 | — | **Constraint** |
+| **R5.3** in-flight バッチの扱い | デプロイ時点で `RUNNING` 状態のバッチがどう振る舞うか | — | **Research Needed** (design phase で決定: hard cutover / runtime feature flag / dual-write) |
+
+### Test Fixture Migration Surface
+
+```
+lambda/batch-runner/tests/
+├── test_async_invoker.py         L955: assert success_row["output_path"].endswith("ok.json")
+├── test_run_async_batch_e2e.py   L252: assert by_stem["ok"]["output_path"].endswith("ok.json")
+│                                 L784: assert deck_pptx_item.get("resultKey", "").endswith("/deck.json")  ← 新仕様で /deck.pptx.json に変更
+├── test_main.py                  L758, L960: "output_path": str(output_dir / f"{stem}.json")
+│                                 L830: assert deck_pptx_item.get("resultKey", "").endswith("/deck.json")  ← 同上
+├── test_batch_store.py           L116, L313, L322, L335, L373, L435, L483, L515, L557, L564
+│                                 (output_path / resultKey assert を {name}.json で書き換え)
+├── test_s3_sync.py               L231, L241, L242, L303 (sample_0.json 等のフィクスチャ — basename 命名は本 spec の影響範囲外、ただし二段拡張子テスト追加)
+└── lambda/api/__tests__/
+    ├── lib/batch-presign.test.ts L220
+    ├── lib/batch-store.test.ts   L175, L243
+    └── routes/batches.test.ts    L116
+```
+
+合計 **約 22 件** の assert / fixture を新仕様 (`{name}.json`) に書き換え。さらに Office 形式 (`deck.pptx.json`) の test case を **新規追加** (PPTX/DOCX/XLSX 各 1 ケース最小)。
+
+### 非機能要件
+
+- **Performance**: 命名変更による hot path への影響なし (string concat 1 回追加のみ)。
+- **Security/Privacy**: ファイル名は API レイヤでサニタイズ済。本 spec で扱う `original_filename` は「サニタイズ後の DDB filename」と一致する前提。
+- **Reliability**: 後方互換破壊 (R4 の migration). API consumer の `resultKey` パース処理が壊れる可能性 → OpenAPI description で事前通知。
+
+## 3. Implementation Approach Options
+
+### Option A: Extend Existing Components (Recommended)
+
+**変更対象ファイル**:
+- `lambda/batch-runner/async_invoker.py` — `persist` ロジックの命名を `f"{file_stem}.json"` → `f"{original_filename}.json"`。引数として `original_name_map: dict[str, str]` を `run_async_batch` から流す
+- `lambda/batch-runner/runner.py` — `generate_all_visualizations` の json→pdf lookup を二段拡張子対応に書き換え。引数 `original_to_pdf_map: dict[str, str]` を追加 (`{deck.pptx: deck.pdf}` の方向で受け取る)
+- `lambda/batch-runner/main.py` — 既存 `pdf_to_original` を `run_async_batch` と `generate_all_visualizations` に追加引数として pipe through (逆向きが必要なら `original_to_pdf` も組み立て)
+- `lambda/api/schemas.ts` — `BatchFile.resultKey` の OpenAPI description 更新
+- 既存テスト fixture 約 22 件の書き換え + Office 形式テスト追加
+- `batch_store.py:297-299` — **変更不要** (`entry.output_path.name` 自動追従)
+
+**Compatibility**: 
+- ✅ 既存 PDF クライアントの場合、入力ファイル名の `.pdf` がそのまま `{name}.pdf.json` に反映 → 後方互換破壊だが OpenAPI description で通知
+- ✅ DDB スキーマ・属性名は不変
+- ❌ 既存 `BatchFile.resultKey` パース処理 (basename 抽出を `.json` で 1 段剥がしている consumer) は破壊される
+
+**Trade-offs**:
+- ✅ 変更が局所化 (3〜4 モジュール + テスト)、新規ファイルなし
+- ✅ 既存 office-format-ingestion の `pdf_to_original` 機構を再利用
+- ✅ Phase 5 の E2E test (`test_run_async_batch_e2e.py`) が既に Office 形式を網羅 → fixture 移行で coverage 維持
+- ❌ 22 箇所の fixture 移行に伴うミスマッチリスク
+- ❌ 移行戦略 (R5.3) を別途決める必要あり
+
+### Option B: Create New Components (Not Recommended)
+
+ファイル命名規約の集約を `naming_policy.py` モジュールとして新設。`async_invoker` と `runner` がそれを参照する形に。
+
+**Trade-offs**:
+- ✅ 命名規約の単一責任化 (将来 `.md`/`.csv` 統一時の拡張点)
+- ❌ 1 関数 (たかだか 5 行) のために新規モジュール追加は YAGNI
+- ❌ 現状 2 箇所の call site のみ → 抽象化の費用対効果が低い
+
+### Option C: Hybrid (Optional Migration Strategy)
+
+Option A + ランタイム feature flag (`RESULT_KEY_NAMING=legacy|extension_preserved`)。
+
+**Trade-offs**:
+- ✅ Production rollback が即時可能
+- ✅ Canary バッチで段階リリース可能
+- ❌ env var 追加で BatchRunnerSettings 拡張が必要
+- ❌ Feature flag 撤去のための後続 PR が必要 (技術的負債リスク)
+- ❌ A consumer がフォーマットを判別できない期間が発生
+
+## 4. Implementation Complexity & Risk
+
+- **Effort: M (3–7 days)**  
+  Code changes は Option A で 3〜4 モジュール + 約 22 箇所の test fixture 書き換え + Office E2E case 追加 + OpenAPI description test。新規パターンや外部依存追加なし。本人作業 ~3 日 + レビュー / 修正バッファ ~2 日。
+
+- **Risk: Medium**  
+  - 後方互換破壊 (`BatchFile.resultKey` 値フォーマット) → API consumer 側の影響。既存の internal consumer (`/batches/{id}` の UI consumer 等) は migration が必要。
+  - ~22 箇所の fixture 書き換えで漏れ発生リスク。Phase 5 の `test_run_async_batch_e2e.py` E2E 網羅と OpenAPI description test で検出可能。
+  - `runner.py` の二段拡張子 lookup 書き換えで visualization regression リスク (Phase 5 R8 と同等の検証が必要)。
+
+## 5. Research Needed (design phase へ持ち越し)
+
+1. **Migration strategy 確定**: 
+   - hard cutover (deploy 後の新規バッチのみ新仕様)
+   - feature flag (`RESULT_KEY_NAMING` env var で制御、staged rollout 後に flag 撤去)
+   - dual-write (deprecation window 中は両 key で書き、reader 側で新→旧 fallback)
+   
+   現状ユースケース (1 アカウント / 内部 API consumer のみ) を踏まえると hard cutover が現実的だが、API description 更新タイミングと CloudFront キャッシュの整合性を design で詰める必要あり。
+
+2. **In-flight batch handling**: デプロイ瞬間に `RUNNING` 状態のバッチが存在した場合、batch-runner のコンテナイメージ更新は次回 task 起動から反映されるため挙動差は出ないが、Step Functions task の長時間実行 (>1h) の場合の整合性を確認。
+
+3. **OpenAPI description のフォーマット**: 単一文字列 description で migration ノートを書ききるか、`x-deprecated-fields` / `x-migration` のような extension key を使うか。Hono + zod-openapi の表現可否を design で確認。
+
+4. **`runner.py` の lookup 失敗時の挙動**: 二段拡張子化に失敗した場合 (例: 想定外の `.json` ファイルが残っている) のフォールバック方針。現状は `pdf_path` が存在しないと silently skip しているが、想定外ケースでの warning ログ追加を検討。
+
+## 6. Recommendations for Design Phase
+
+### 推奨アプローチ
+- **Option A (Extend Existing Components)** を採用
+- 移行戦略は **hard cutover** をベースに検討 (内部 consumer のみのため実現可能性高い)。Feature flag は overhead を勘案して不採用候補
+- `pdf_to_original` を逆向きにした `original_to_pdf` map (`{deck.pptx: deck.pdf}`) を `main.py` で組み立て、`run_async_batch` と `generate_all_visualizations` の両方に pipe through
+
+### 主要設計判断ポイント
+1. 引数の型: `dict[str, str]` でシンプルに保つか、`@dataclass(frozen=True) FilenameMapping` を導入するか
+2. `async_invoker` の internal API: `original_name_map` を `AsyncInvoker.__init__` に持たせるか、`run_async_batch` 関数引数で都度渡すか (現状 1 batch = 1 invocation のため後者で十分)
+3. 可視化 lookup 失敗時の error reporting 方針 (silent skip 維持 / warning ログ追加 / metric 化)
+4. OpenAPI migration ノートの書き方と内部 consumer (CloudFront UI など) への通知タイミング
+
+### Carry-Forward Research Items
+- (R5.3) Migration strategy 最終決定 — design 段階で確定
+- (R4.1-R4.4) OpenAPI description の具体的な文言ドラフト — design 段階で記述
+- runner.py lookup 失敗時の error policy — design 段階で確定
+
+---
+
+## Design Synthesis Outcomes (2026-04-27)
+
+### 1. Generalization
+- R1.1 (PDF), R1.2 (PPTX), R1.3 (DOCX/XLSX), R1.4 (非 ASCII / サニタイズ) は同一の問題「ローカル basename → 原本ファイル名のマッピングを使って JSON 命名する」のバリエーション
+- 一般化された capability: **filename mapping** (`local_basename → original_input_filename` および逆向き)
+- ネイティブ PDF: identity (entry なし → `dict.get(key, key)` で fallback)
+- Office: 明示的な entry (`convert_office_files` の戻り値から構築)
+
+### 2. Build vs. Adopt
+- **Adopt** (再利用): `office-format-ingestion` で導入された `pdf_to_original` 構築ロジック (`main.py:201-221`)、`apply_process_log(..., converted_filename_map)` 機構、`ConvertResult.succeeded[ConvertedFile(original_path, pdf_path)]` データ構造
+- **Build** (新規): なし。既存マッピングを `async_invoker` / `runner` にも pipe through するための引数追加に閉じる
+- 外部ライブラリ追加なし
+
+### 3. Simplification
+- **却下**: `naming_policy.py` 新規モジュール (research の Option B) — 1 関数 5 行のために抽象化費用対効果が低い (YAGNI)
+- **却下**: Feature flag による段階移行 (research の Option C) — 内部 consumer のみ + Fargate task 単位 deploy で in-flight 影響なしのため hard cutover が現実的
+- **却下**: `@dataclass(frozen=True) FilenameMapping` ラッパー — `dict[str, str]` 1 つで完結するため不要
+- **採用**: シンプルな `dict[str, str]` を関数引数で渡す (steering の「副作用のない純粋関数」原則と整合)
+
+### Final Design Decisions
+- **Mapping ownership**: `main.py` がオーケストレータとして両方向 map (`local_to_original` / `original_to_local`) を所有、下流モジュールは引数で受け取る
+- **Migration strategy**: hard cutover (no feature flag, no dual-write, no migration script)
+- **In-flight handling**: Fargate task 単位 deploy のため、deploy 瞬間に走っている task は旧 image で完了する (Step Functions Execution の startedAt が deploy 時刻より早ければ旧フォーマット、それ以降は新フォーマット)
+- **Lookup failure policy**: 既存挙動を維持 (silent skip + warning ログ)、エラーメッセージのみ「local PDF not found: {basename}」に更新
+
+### Design Review Gate Status
+- Mechanical checks: 全 19 numeric requirement IDs が design.md の Traceability Table に出現 ✅
+- Boundary section populated: This Spec Owns / Out of Boundary / Allowed Dependencies / Revalidation Triggers すべて記述済 ✅
+- File Structure Plan: 具体的 path とファイルごとの責務を記述 ✅
+- No orphan components: 4 component (`main.py`, `async_invoker`, `runner`, `schemas.ts`) すべて File Structure Plan に対応 ✅

--- a/.kiro/specs/result-filename-extension-preservation/spec.json
+++ b/.kiro/specs/result-filename-extension-preservation/spec.json
@@ -1,9 +1,9 @@
 {
   "feature_name": "result-filename-extension-preservation",
   "created_at": "2026-04-27T13:09:38Z",
-  "updated_at": "2026-04-27T14:02:10Z",
+  "updated_at": "2026-04-27T23:43:30Z",
   "language": "ja",
-  "phase": "tasks-generated",
+  "phase": "implementation-complete",
   "approvals": {
     "requirements": {
       "generated": true,

--- a/.kiro/specs/result-filename-extension-preservation/spec.json
+++ b/.kiro/specs/result-filename-extension-preservation/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "result-filename-extension-preservation",
+  "created_at": "2026-04-27T13:09:38Z",
+  "updated_at": "2026-04-27T14:02:10Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -31,7 +31,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4_
   - _Boundary: runner.generate_all_visualizations_
 
-- [ ] 2.3 (P) `BatchFile.resultKey` の OpenAPI description を新フォーマット仕様に更新
+- [x] 2.3 (P) `BatchFile.resultKey` の OpenAPI description を新フォーマット仕様に更新
   - `lambda/api/schemas.ts` L367-371 の `BatchFile.resultKey` schema description を以下の 4 要素を含む文字列に書換: (1) 値フォーマット `batches/{batchJobId}/output/{原本ファイル名}.json` (`{原本ファイル名}` は `BatchFile.filename` と一致、原本拡張子を含む) と例示 (`report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`)、(2) 旧フォーマット (`{stem}.json`) からの変更点と既存 consumer の basename 抽出処理への影響を含む移行ノート、(3) 属性名 `resultKey` および `.json` 終端は不変 (R4.3)、(4) yomitoku-client が出力する追加フォーマット (`.md` / `.csv` / `.html`) は本 spec の対象外で、命名は yomitoku-client 規約のまま、将来 spec で統一の可能性ありという非対称メモ
   - `example` プロパティを `batches/abc-123/output/document.pdf.json` に更新
   - **観察可能な完了**: `pnpm cdk synth ApiStack` が成功し、生成された OpenAPI ドキュメントの `BatchFile.resultKey.description` に上記 4 要素が含まれる

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. Foundation — フィルナムマッピングヘルパ
 
-- [ ] 1.1 `office_converter.build_filename_maps` ヘルパ関数を追加
+- [x] 1.1 `office_converter.build_filename_maps` ヘルパ関数を追加
   - `ConvertResult` を受け取り、`(local_to_original, original_to_local)` の双方向マッピングを 1 箇所で原子的に構築する関数を実装する (Single Source of Truth、Critical Issue 1 への design 解決策 案 A)
   - `convert_result.succeeded` (`ConvertedFile(original_path, pdf_path)` の list) を走査し、key/value を Path.name ベースで構築。`succeeded` が空であれば両 map とも空 dict を返す
   - 関数の戻り値型は `tuple[dict[str, str], dict[str, str]]` で型ヒント明示

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -1,0 +1,95 @@
+# Implementation Plan
+
+## 1. Foundation — フィルナムマッピングヘルパ
+
+- [ ] 1.1 `office_converter.build_filename_maps` ヘルパ関数を追加
+  - `ConvertResult` を受け取り、`(local_to_original, original_to_local)` の双方向マッピングを 1 箇所で原子的に構築する関数を実装する (Single Source of Truth、Critical Issue 1 への design 解決策 案 A)
+  - `convert_result.succeeded` (`ConvertedFile(original_path, pdf_path)` の list) を走査し、key/value を Path.name ベースで構築。`succeeded` が空であれば両 map とも空 dict を返す
+  - 関数の戻り値型は `tuple[dict[str, str], dict[str, str]]` で型ヒント明示
+  - `test_office_converter.py` に新規ユニットテストを追加: 単一 ConvertedFile / 複数 / 空入力の 3 ケースで両 map が完全な逆引き関係 (`local_to_original[v] == k for k, v in original_to_local.items()`) であることを assert
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/test_office_converter.py::test_build_filename_maps` が pass し、新ヘルパ関数が 3 ケースで invariant を満たす
+  - _Requirements: 1.2, 1.3, 2.2, 2.3_
+
+## 2. Core — 各モジュールの命名 / lookup ロジック改修 (並列実行可能)
+
+- [ ] 2.1 (P) `async_invoker` の JSON persist 命名規約を `{原本ファイル名}.json` に変更
+  - `run_async_batch` 関数および `AsyncInvoker.__init__` (または `run_batch` メソッド) に `local_to_original: dict[str, str] | None = None` 引数を追加し、`AsyncInvoker._drain_queue` 内で参照可能にする
+  - `_drain_queue` の persist パス組み立てを `output_dir / f"{file_stem}.json"` から `output_dir / f"{output_filename}.json"` に変更。`output_filename = (local_to_original or {}).get(file_path.name, file_path.name)` で解決
+  - SageMaker `InferenceId` 用の `_safe_ident` (SHA-1 16 文字) は persist パス計算に **使わない**。ローカル persist には API レイヤでサニタイズ済の filename をそのまま使用する (R1.4 invariant)
+  - `test_async_invoker.py` を更新: 既存 `endswith("ok.json")` を `endswith("ok.pdf.json")` に書換、新規ケースとして (a) PDF 入力 → `report.pdf.json`、(b) `local_to_original={"deck.pdf": "deck.pptx"}` 経由 Office → `deck.pptx.json`、(c) 非 ASCII / サニタイズ済 filename (例: `_____.pdf` → `_____.pdf.json`) の 3 ケース、いずれも persist パスに `_safe_ident` 由来の SHA-1 文字列が含まれないことを assert
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/test_async_invoker.py` が全件 pass し、新仕様で persist された JSON ファイルパスが原本ファイル名 + `.json` で終端する
+  - _Requirements: 1.1, 1.2, 1.3, 1.4_
+  - _Boundary: AsyncInvoker_
+
+- [ ] 2.2 (P) `runner.generate_all_visualizations` の二段拡張子 lookup 対応
+  - 関数シグネチャに `original_to_local: dict[str, str] | None = None` 引数を追加
+  - lookup ロジックを書換: `original_input_name = json_file.name[:-len(".json")]` で `.json` を 1 段だけ剥がし、`local_pdf_basename = (original_to_local or {}).get(original_input_name, original_input_name)` で local PDF basename を解決、`pdf_path = in_path / local_pdf_basename`
+  - lookup 失敗時 (`pdf_path.exists() == False`) は既存挙動と同じ silent skip + warning ログを維持。エラーメッセージのみ `"local PDF not found: {local_pdf_basename}"` に更新
+  - 可視化 JPEG ファイル名 (`{basename}_{mode}_page_{idx}.jpg`) は既存規約据え置き (R2.4)
+  - `test_runner.py` を更新 / 追加: (a) PDF native (`report.pdf.json` + 空 `original_to_local` → `report.pdf` 解決)、(b) Office case (`deck.pptx.json` + `original_to_local={"deck.pptx": "deck.pdf"}` → `deck.pdf` 解決)、(c) lookup miss (該当 PDF 不在 → `errors_per_file` に記録) の 3 ケース
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/test_runner.py` が全件 pass し、両形式の JSON から正しい local PDF が解決される
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+  - _Boundary: runner.generate_all_visualizations_
+
+- [ ] 2.3 (P) `BatchFile.resultKey` の OpenAPI description を新フォーマット仕様に更新
+  - `lambda/api/schemas.ts` L367-371 の `BatchFile.resultKey` schema description を以下の 4 要素を含む文字列に書換: (1) 値フォーマット `batches/{batchJobId}/output/{原本ファイル名}.json` (`{原本ファイル名}` は `BatchFile.filename` と一致、原本拡張子を含む) と例示 (`report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`)、(2) 旧フォーマット (`{stem}.json`) からの変更点と既存 consumer の basename 抽出処理への影響を含む移行ノート、(3) 属性名 `resultKey` および `.json` 終端は不変 (R4.3)、(4) yomitoku-client が出力する追加フォーマット (`.md` / `.csv` / `.html`) は本 spec の対象外で、命名は yomitoku-client 規約のまま、将来 spec で統一の可能性ありという非対称メモ
+  - `example` プロパティを `batches/abc-123/output/document.pdf.json` に更新
+  - **観察可能な完了**: `pnpm cdk synth ApiStack` が成功し、生成された OpenAPI ドキュメントの `BatchFile.resultKey.description` に上記 4 要素が含まれる
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - _Boundary: lambda/api/schemas.ts BatchFile_
+
+## 3. Integration — `main.py` のオーケストレーション配線
+
+- [ ] 3.1 `main.py` でフィルナムマッピングを構築し下流モジュールに pipe through
+  - 既存の `pdf_to_original` 構築ロジック (L201-221) を `office_converter.build_filename_maps(convert_result)` の戻り値で置き換え、`local_to_original` および `original_to_local` の 2 変数を取得
+  - `apply_process_log(..., converted_filename_map=local_to_original)` の呼び出しは引数名を維持しつつ value を新変数 `local_to_original` を流用 (Bug 001 互換維持)
+  - `run_async_batch(...)` 呼び出しに `local_to_original=local_to_original` を追加
+  - `generate_all_visualizations(...)` 呼び出しに `original_to_local=original_to_local` を追加
+  - ネイティブ PDF のみのバッチでは両 map が空 dict のまま下流に渡され、identity 解決で新仕様 (`{name}.pdf.json`) が PDF にも自動適用されることを保証
+  - `test_main.py` の既存ケースを更新: 混在バッチ (PDF + Office + 変換失敗) の E2E で `local_to_original` / `original_to_local` が `run_async_batch` / `generate_all_visualizations` / `apply_process_log` の 3 箇所に正しく届くことを mock assert
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/test_main.py` が全件 pass し、orchestrator 経由で各 sub-module に正しい map が注入される
+  - _Depends: 1.1, 2.1, 2.2_
+  - _Requirements: 1.1, 1.2, 1.3, 1.5, 2.1, 2.2, 2.3_
+  - _Boundary: main.py orchestrator_
+
+## 4. Test Fixture 移行 — 旧フォーマット `{stem}.json` の書換 (並列実行可能)
+
+- [ ] 4.1 (P) Python テスト fixture を新仕様 (`{name}.json`) へ移行
+  - `lambda/batch-runner/tests/test_async_invoker.py` (L955) / `test_run_async_batch_e2e.py` (L252, L784) / `test_main.py` (L758, L830, L960) / `test_batch_store.py` (L116, L313, L322, L335, L373, L435, L483, L515, L557, L564) の `output_path` / `resultKey` リテラルおよび `f"{stem}.json"` 系構築式を新フォーマット (`{name}.json`、Office は `{name}.pptx.json` 等) に書換
+  - 新規テストケース追加: (a) `test_run_async_batch_e2e.py` で混在バッチ (PDF + PPTX + DOCX + XLSX + 変換失敗 PPTX) の resultKey 全件検証、(b) `test_async_invoker.py` で非 ASCII filename ケース (R1.4 ガード)、(c) 既存バッチ fixture を pre-populate しておき、新仕様 deploy 後にその resultKey 値が遡及更新されないことを assert (R5.1, R5.2)
+  - 失敗ケース (CONVERSION_FAILED / OCR_FAILED) で resultKey が未設定であることを既存テストで再検証 (R3.1, R3.2)
+  - PENDING / PROCESSING 状態の FILE で resultKey が DDB に存在しないことを assert (R3.3)
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/` が全件 pass し、旧フォーマット `{stem}.json` の assert / fixture が完全に新フォーマットに置き換わっている
+  - _Depends: 2.1, 2.2, 3.1_
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 5.1, 5.2_
+  - _Boundary: lambda/batch-runner/tests/_
+
+- [ ] 4.2 (P) TypeScript テスト fixture を新仕様 (`{name}.json`) へ移行
+  - `lambda/api/__tests__/lib/batch-presign.test.ts` (L220) / `batch-store.test.ts` (L175, L243) / `routes/batches.test.ts` (L116) の `resultKey` 値リテラル (`output/sample.json` / `output/a.json` 等) を新フォーマット (例: `output/document.pdf.json` / `output/a.pdf.json`) に書換
+  - `lambda/api/__tests__/openapi-description.test.ts` に新規アサーション追加: `BatchFile.resultKey.description` が「`{原本ファイル名}.json`」「移行ノート」「追加フォーマット非対称メモ」「`.json` 終端不変」の 4 要素文言を含むことを検証 (R4.1, R4.2, R4.3, R4.4)
+  - **観察可能な完了**: `pnpm test` (Vitest) が全件 pass し、OpenAPI description テストが新仕様の 4 要素文言を確認する
+  - _Depends: 2.3_
+  - _Requirements: 1.5, 4.1, 4.2, 4.3, 4.4_
+  - _Boundary: lambda/api/__tests__/_
+
+## 5. Validation — 契約ガードと E2E
+
+- [ ] 5.1 Legacy reference contract guard (移行漏れ検出機構) の実装
+  - `scripts/check-legacy-refs.sh` を拡張、または新規 `scripts/check-result-key-format.sh` を作成し、以下の正規表現で旧フォーマット fixture / 構築式の取り残しを検出する: (a) `output_dir\s*/\s*f"\{(?:file_)?stem\}\.json"` (Python `f"{stem}.json"` 系)、(b) `output/[a-zA-Z0-9_-]+\.json["']` (拡張子なし basename + `.json` のリテラル)
+  - 除外リスト (false positive 防止): `process_log.jsonl` / `_async/outputs/{uuid}.out` / yomitoku-client 規約 (`{stem}_{ext}.json` の `extra_formats` 出力) / 本 script 自体
+  - 違反 1 件以上で `exit 1`、0 件で `exit 0` を返す
+  - `pnpm lint` の実行チェーンに統合 (現状 `pnpm lint` は biome + check-legacy-refs を呼ぶため、同所に追加)
+  - 契約テストとして `test/check-legacy-refs.test.ts` パターンに準拠する Vitest 単体ケースを追加 (`scripts/check-result-key-format.sh` を runtime 起動して `exit 0` を確認)
+  - **観察可能な完了**: 違反コードを意図的に追加して `pnpm lint` を実行すると `exit 1` で失敗し、適切に取り除くと `exit 0` で成功する
+  - _Depends: 4.1, 4.2_
+  - _Requirements: 1.1, 1.2, 1.3, 1.5, 4.1_
+  - _Boundary: scripts/, test/_
+
+- [ ] 5.2 E2E 混在バッチ統合テスト (`test_run_async_batch_e2e.py`) の新仕様再検証
+  - 既存の混在バッチ test case (PDF + PPTX + 変換失敗 PPTX) を新仕様で再アサート: `BatchFile.resultKey` が `/{name}.{ext}.json` 終端、可視化 JPEG が `{stem}_{mode}_page_{idx}.jpg` 形式で生成、`CONVERSION_FAILED` / `OCR_FAILED` で resultKey 未設定、PENDING/PROCESSING で resultKey 不在
+  - 既存バッチ非影響シナリオ: pre-existing fixture として旧フォーマット `resultKey="batches/old/output/legacy.json"` を持つ FILE 行を DDB に投入 → 新仕様の `apply_process_log` を別バッチで実行 → 旧バッチの resultKey 値が unchanged であることを assert (R5.1, R5.2)
+  - In-flight handling シナリオ: 新仕様コードを 1 バッチ走らせた後、別の新規バッチで `{name}.{ext}.json` 形式が一貫して生成されることを assert (R5.3、Fargate task 単位 deploy のセマンティクスを moto + Stubber で再現)
+  - **観察可能な完了**: `pytest lambda/batch-runner/tests/test_run_async_batch_e2e.py` が全件 pass し、混在バッチで R1〜R5 の全 ACs が moto + Stubber 経由で観測される
+  - _Depends: 3.1, 4.1_
+  - _Requirements: 1.1, 1.2, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 5.1, 5.2, 5.3_
+  - _Boundary: lambda/batch-runner/tests/test_run_async_batch_e2e.py_

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -40,7 +40,7 @@
 
 ## 3. Integration — `main.py` のオーケストレーション配線
 
-- [ ] 3.1 `main.py` でフィルナムマッピングを構築し下流モジュールに pipe through
+- [x] 3.1 `main.py` でフィルナムマッピングを構築し下流モジュールに pipe through
   - 既存の `pdf_to_original` 構築ロジック (L201-221) を `office_converter.build_filename_maps(convert_result)` の戻り値で置き換え、`local_to_original` および `original_to_local` の 2 変数を取得
   - `apply_process_log(..., converted_filename_map=local_to_original)` の呼び出しは引数名を維持しつつ value を新変数 `local_to_original` を流用 (Bug 001 互換維持)
   - `run_async_batch(...)` 呼び出しに `local_to_original=local_to_original` を追加
@@ -93,3 +93,7 @@
   - _Depends: 3.1, 4.1_
   - _Requirements: 1.1, 1.2, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 5.1, 5.2, 5.3_
   - _Boundary: lambda/batch-runner/tests/test_run_async_batch_e2e.py_
+
+## Implementation Notes
+
+- **Task 2.1 boundary blind spot**: Task 2.1 added `local_to_original` to `AsyncInvoker.__init__` (in `async_invoker.py`) but missed the `run_async_batch` wrapper function that lives in `runner.py:39` (NOT in `async_invoker.py`). Discovered during Task 3.1 implementation when `main.py` started passing `local_to_original=...` to `runner.run_async_batch(...)`. Fixed in Task 3.1's commit by extending the boundary to include `runner.py:run_async_batch` signature and AsyncInvoker forward. Future tasks: when a "function in module X" boundary is declared, check both the source module AND any wrapper functions exported from sibling modules.

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -85,7 +85,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.5, 4.1_
   - _Boundary: scripts/, test/_
 
-- [ ] 5.2 E2E 混在バッチ統合テスト (`test_run_async_batch_e2e.py`) の新仕様再検証
+- [x] 5.2 E2E 混在バッチ統合テスト (`test_run_async_batch_e2e.py`) の新仕様再検証
   - 既存の混在バッチ test case (PDF + PPTX + 変換失敗 PPTX) を新仕様で再アサート: `BatchFile.resultKey` が `/{name}.{ext}.json` 終端、可視化 JPEG が `{stem}_{mode}_page_{idx}.jpg` 形式で生成、`CONVERSION_FAILED` / `OCR_FAILED` で resultKey 未設定、PENDING/PROCESSING で resultKey 不在
   - 既存バッチ非影響シナリオ: pre-existing fixture として旧フォーマット `resultKey="batches/old/output/legacy.json"` を持つ FILE 行を DDB に投入 → 新仕様の `apply_process_log` を別バッチで実行 → 旧バッチの resultKey 値が unchanged であることを assert (R5.1, R5.2)
   - In-flight handling シナリオ: 新仕様コードを 1 バッチ走らせた後、別の新規バッチで `{name}.{ext}.json` 形式が一貫して生成されることを assert (R5.3、Fargate task 単位 deploy のセマンティクスを moto + Stubber で再現)

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -54,7 +54,7 @@
 
 ## 4. Test Fixture 移行 — 旧フォーマット `{stem}.json` の書換 (並列実行可能)
 
-- [ ] 4.1 (P) Python テスト fixture を新仕様 (`{name}.json`) へ移行
+- [x] 4.1 (P) Python テスト fixture を新仕様 (`{name}.json`) へ移行
   - `lambda/batch-runner/tests/test_async_invoker.py` (L955) / `test_run_async_batch_e2e.py` (L252, L784) / `test_main.py` (L758, L830, L960) / `test_batch_store.py` (L116, L313, L322, L335, L373, L435, L483, L515, L557, L564) の `output_path` / `resultKey` リテラルおよび `f"{stem}.json"` 系構築式を新フォーマット (`{name}.json`、Office は `{name}.pptx.json` 等) に書換
   - 新規テストケース追加: (a) `test_run_async_batch_e2e.py` で混在バッチ (PDF + PPTX + DOCX + XLSX + 変換失敗 PPTX) の resultKey 全件検証、(b) `test_async_invoker.py` で非 ASCII filename ケース (R1.4 ガード)、(c) 既存バッチ fixture を pre-populate しておき、新仕様 deploy 後にその resultKey 値が遡及更新されないことを assert (R5.1, R5.2)
   - 失敗ケース (CONVERSION_FAILED / OCR_FAILED) で resultKey が未設定であることを既存テストで再検証 (R3.1, R3.2)

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -74,7 +74,7 @@
 
 ## 5. Validation — 契約ガードと E2E
 
-- [ ] 5.1 Legacy reference contract guard (移行漏れ検出機構) の実装
+- [x] 5.1 Legacy reference contract guard (移行漏れ検出機構) の実装
   - `scripts/check-legacy-refs.sh` を拡張、または新規 `scripts/check-result-key-format.sh` を作成し、以下の正規表現で旧フォーマット fixture / 構築式の取り残しを検出する: (a) `output_dir\s*/\s*f"\{(?:file_)?stem\}\.json"` (Python `f"{stem}.json"` 系)、(b) `output/[a-zA-Z0-9_-]+\.json["']` (拡張子なし basename + `.json` のリテラル)
   - 除外リスト (false positive 防止): `process_log.jsonl` / `_async/outputs/{uuid}.out` / yomitoku-client 規約 (`{stem}_{ext}.json` の `extra_formats` 出力) / 本 script 自体
   - 違反 1 件以上で `exit 1`、0 件で `exit 0` を返す

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -21,7 +21,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4_
   - _Boundary: AsyncInvoker_
 
-- [ ] 2.2 (P) `runner.generate_all_visualizations` の二段拡張子 lookup 対応
+- [x] 2.2 (P) `runner.generate_all_visualizations` の二段拡張子 lookup 対応
   - 関数シグネチャに `original_to_local: dict[str, str] | None = None` 引数を追加
   - lookup ロジックを書換: `original_input_name = json_file.name[:-len(".json")]` で `.json` を 1 段だけ剥がし、`local_pdf_basename = (original_to_local or {}).get(original_input_name, original_input_name)` で local PDF basename を解決、`pdf_path = in_path / local_pdf_basename`
   - lookup 失敗時 (`pdf_path.exists() == False`) は既存挙動と同じ silent skip + warning ログを維持。エラーメッセージのみ `"local PDF not found: {local_pdf_basename}"` に更新

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -64,7 +64,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 5.1, 5.2_
   - _Boundary: lambda/batch-runner/tests/_
 
-- [ ] 4.2 (P) TypeScript テスト fixture を新仕様 (`{name}.json`) へ移行
+- [x] 4.2 (P) TypeScript テスト fixture を新仕様 (`{name}.json`) へ移行
   - `lambda/api/__tests__/lib/batch-presign.test.ts` (L220) / `batch-store.test.ts` (L175, L243) / `routes/batches.test.ts` (L116) の `resultKey` 値リテラル (`output/sample.json` / `output/a.json` 等) を新フォーマット (例: `output/document.pdf.json` / `output/a.pdf.json`) に書換
   - `lambda/api/__tests__/openapi-description.test.ts` に新規アサーション追加: `BatchFile.resultKey.description` が「`{原本ファイル名}.json`」「移行ノート」「追加フォーマット非対称メモ」「`.json` 終端不変」の 4 要素文言を含むことを検証 (R4.1, R4.2, R4.3, R4.4)
   - **観察可能な完了**: `pnpm test` (Vitest) が全件 pass し、OpenAPI description テストが新仕様の 4 要素文言を確認する

--- a/.kiro/specs/result-filename-extension-preservation/tasks.md
+++ b/.kiro/specs/result-filename-extension-preservation/tasks.md
@@ -12,7 +12,7 @@
 
 ## 2. Core — 各モジュールの命名 / lookup ロジック改修 (並列実行可能)
 
-- [ ] 2.1 (P) `async_invoker` の JSON persist 命名規約を `{原本ファイル名}.json` に変更
+- [x] 2.1 (P) `async_invoker` の JSON persist 命名規約を `{原本ファイル名}.json` に変更
   - `run_async_batch` 関数および `AsyncInvoker.__init__` (または `run_batch` メソッド) に `local_to_original: dict[str, str] | None = None` 引数を追加し、`AsyncInvoker._drain_queue` 内で参照可能にする
   - `_drain_queue` の persist パス組み立てを `output_dir / f"{file_stem}.json"` から `output_dir / f"{output_filename}.json"` に変更。`output_filename = (local_to_original or {}).get(file_path.name, file_path.name)` で解決
   - SageMaker `InferenceId` 用の `_safe_ident` (SHA-1 16 文字) は persist パス計算に **使わない**。ローカル persist には API レイヤでサニタイズ済の filename をそのまま使用する (R1.4 invariant)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ curl "https://<DistributionDomainName>/batches/<batchJobId>/files?cursor=<cursor
       "status": "COMPLETED",
       "dpi": 200,
       "processingTimeMs": 12345,
-      "resultKey": "batches/.../output/doc-a.json",
+      "resultKey": "batches/.../output/doc-a.pdf.json",
       "updatedAt": "2026-04-22T00:03:00.000Z"
     }
   ],

--- a/lambda/api/__tests__/lib/batch-presign.test.ts
+++ b/lambda/api/__tests__/lib/batch-presign.test.ts
@@ -217,7 +217,7 @@ describe("BatchPresign", () => {
   describe("createResultUrl", () => {
     it("結果 JSON 向け署名付き GET URL を発行する（有効期限 60 分）", async () => {
       const url = await presign.createResultUrl(
-        "batches/batch-001/output/sample.json",
+        "batches/batch-001/output/sample.pdf.json",
       );
 
       expect(url).toContain("https://");

--- a/lambda/api/__tests__/lib/batch-store.test.ts
+++ b/lambda/api/__tests__/lib/batch-store.test.ts
@@ -172,7 +172,7 @@ describe("BatchStore (write-path)", () => {
         fileKey: "batches/batch-001/input/a.pdf",
         status: "COMPLETED",
         processingTimeMs: 1200,
-        resultKey: "batches/batch-001/output/a.json",
+        resultKey: "batches/batch-001/output/a.pdf.json",
       });
 
       const cmd: AnyRecord = mockSend.mock.calls[0][0];
@@ -240,7 +240,7 @@ describe("BatchStore (write-path)", () => {
         fileKey: "batches/batch-001/input/a.pdf",
         status: "COMPLETED",
         processingTimeMs: 1200,
-        resultKey: "batches/batch-001/output/a.json",
+        resultKey: "batches/batch-001/output/a.pdf.json",
       });
 
       const cmd: AnyRecord = mockSend.mock.calls[0][0];

--- a/lambda/api/__tests__/openapi-description.test.ts
+++ b/lambda/api/__tests__/openapi-description.test.ts
@@ -44,6 +44,45 @@ async function fetchOpenApiDescription(): Promise<string> {
   return description;
 }
 
+/**
+ * Task 4.2 用ヘルパ:
+ *   `/doc` の JSON ペイロードから `components.schemas.BatchFile.properties.resultKey.description`
+ *   を取り出して返す。`BatchFile.resultKey` の OpenAPI description が
+ *   result-filename-extension-preservation 仕様 (R4.1 / R4.2 / R4.3 / R4.4)
+ *   に追従していることを検証する用途。
+ */
+async function fetchBatchFileResultKeyDescription(): Promise<string> {
+  const mod = await import("../index");
+  const app = (mod as { app?: { fetch: (req: Request) => Promise<Response> } })
+    .app;
+  if (!app) {
+    throw new Error(
+      "index.ts must export the OpenAPIHono `app` instance for unit tests",
+    );
+  }
+  const res = await app.fetch(new Request("http://localhost/doc"));
+  expect(res.status).toBe(200);
+  const doc = (await res.json()) as {
+    components?: {
+      schemas?: {
+        BatchFile?: {
+          properties?: {
+            resultKey?: { description?: string };
+          };
+        };
+      };
+    };
+  };
+  const description =
+    doc.components?.schemas?.BatchFile?.properties?.resultKey?.description;
+  if (typeof description !== "string") {
+    throw new Error(
+      "components.schemas.BatchFile.properties.resultKey.description was not a string",
+    );
+  }
+  return description;
+}
+
 describe("Task 2.4 — OpenAPI info.description の Office 形式対応", () => {
   it("PUT 説明 (:37) に Office 形式 4 種と OOXML MIME を併記している", async () => {
     const description = await fetchOpenApiDescription();
@@ -88,5 +127,54 @@ describe("Task 2.4 — OpenAPI info.description の Office 形式対応", () => 
     expect(description).toContain("LibreOffice");
     // 旧文言「拡張子は **`.pdf`** のみ」が残っていないこと
     expect(description).not.toMatch(/拡張子は\s*\*\*`\.pdf`\*\*\s*のみ/);
+  });
+});
+
+describe("Task 4.2 — BatchFile.resultKey description の result-filename-extension-preservation 仕様 (R4.1-R4.4)", () => {
+  it("R4.1: 値フォーマット `{原本ファイル名}.json` と 4 種例示 (PDF/PPTX/DOCX/XLSX) が含まれる", async () => {
+    const description = await fetchBatchFileResultKeyDescription();
+    // 値フォーマットの記述
+    expect(description).toContain("{原本ファイル名}.json");
+    // 4 種の例示すべて
+    expect(description).toContain("report.pdf.json");
+    expect(description).toContain("deck.pptx.json");
+    expect(description).toContain("report.docx.json");
+    expect(description).toContain("report.xlsx.json");
+  });
+
+  it("R4.2: 旧フォーマット `{stem}.json` への言及と consumer 影響の移行ノートが含まれる", async () => {
+    const description = await fetchBatchFileResultKeyDescription();
+    // 旧フォーマットへの言及 (stem ベース)
+    expect(description).toContain("{stem}.json");
+    // 既存 consumer の basename 抽出処理への影響説明
+    // (basename / 1 段 / 抽出 等のキーワードを期待)
+    expect(description).toMatch(/basename|1 段|抽出/);
+  });
+
+  it("R4.3: `.json` 終端不変 + `resultKey` 属性名不変の invariant が明示されている", async () => {
+    const description = await fetchBatchFileResultKeyDescription();
+    // `.json` 終端の不変性
+    expect(description).toMatch(/\.json.*終端|終端.*\.json/);
+    // 属性名 `resultKey` の不変性 + 「変更されません」等の文言
+    expect(description).toContain("resultKey");
+    expect(description).toMatch(/変更されません|不変|変えない/);
+  });
+
+  it("R4.4: 追加フォーマット (`.md` / `.csv` / `.html`) との非対称メモが含まれる", async () => {
+    const description = await fetchBatchFileResultKeyDescription();
+    // 追加フォーマット 3 種への言及
+    expect(description).toContain(".md");
+    expect(description).toContain(".csv");
+    expect(description).toContain(".html");
+    // yomitoku-client 規約への言及
+    expect(description).toContain("yomitoku-client");
+  });
+
+  it("既存情報の保持: status=COMPLETED 限定句 と resultUrl 案内が losslessly に維持されている", async () => {
+    const description = await fetchBatchFileResultKeyDescription();
+    // 既存の `status=COMPLETED` 限定句
+    expect(description).toContain("status=COMPLETED");
+    // 既存の resultUrl 案内
+    expect(description).toContain("resultUrl");
   });
 });

--- a/lambda/api/__tests__/routes/batches.test.ts
+++ b/lambda/api/__tests__/routes/batches.test.ts
@@ -113,7 +113,8 @@ const MOCK_BATCH_WITH_FILES = {
       fileKey: "batches/00000000-0000-4000-8000-000000000001/input/a.pdf",
       filename: "a.pdf",
       status: "COMPLETED" as const,
-      resultKey: "batches/00000000-0000-4000-8000-000000000001/output/a.json",
+      resultKey:
+        "batches/00000000-0000-4000-8000-000000000001/output/a.pdf.json",
       updatedAt: "2026-04-22T00:10:00Z",
     },
     {

--- a/lambda/api/schemas.ts
+++ b/lambda/api/schemas.ts
@@ -364,11 +364,24 @@ export const BatchFileSchema = z
     processingTimeMs: z.number().int().optional().openapi({
       description: "ミリ秒単位の処理時間 (成功時のみ)",
     }),
-    resultKey: z.string().optional().openapi({
-      description:
-        "結果 JSON の S3 オブジェクトキー (`status=COMPLETED` のときのみ存在)。署名付き URL は `resultUrl` を使ってください。",
-      example: "batches/abc-123/output/document.json",
-    }),
+    resultKey: z
+      .string()
+      .optional()
+      .openapi({
+        description: [
+          "結果 JSON の S3 オブジェクトキー (`status=COMPLETED` のときのみ存在)。署名付き URL は `resultUrl` を使ってください。",
+          "",
+          "**値フォーマット**: `batches/{batchJobId}/output/{原本ファイル名}.json`",
+          "- `{原本ファイル名}` は `BatchFile.filename` と一致し、原本拡張子を含む (例: `report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`)。",
+          "",
+          "**移行ノート**: 旧フォーマットは `batches/{batchJobId}/output/{stem}.json` (拡張子を除いた basename + `.json`) でした。本変更により `.json` 直前のファイル名部分に原本拡張子が含まれるようになります。`resultKey` から basename を抽出している既存 consumer (`.json` を 1 段だけ剥がす実装) は、抽出後の値に原本拡張子が残る点に注意してください (例: 旧 `report` → 新 `report.pdf`)。",
+          "",
+          "**不変 invariant**: 属性名 `resultKey` および値が `.json` で終端することは変更されません (R4.3)。",
+          "",
+          "**追加フォーマットとの非対称メモ**: yomitoku-client が出力する追加フォーマット (`.md` / `.csv` / `.html`) は本仕様の対象外で、命名は yomitoku-client 規約 (`{stem}_{ext}.json` 等) のままです。メイン JSON (`report.pdf.json`) と追加フォーマット (`report.md` 等) の命名は一時的に非対称となりますが、将来 spec で統一する可能性があります。",
+        ].join("\n"),
+        example: "batches/abc-123/output/document.pdf.json",
+      }),
     resultUrl: z
       .string()
       .url()

--- a/lambda/batch-runner/async_invoker.py
+++ b/lambda/batch-runner/async_invoker.py
@@ -16,8 +16,12 @@ Task 3.1 〜 3.3 / 5.1 を通じて以下を担う:
       まで待機し、未完了 InferenceId は ``BatchResult.in_flight_timeout`` に
       集計する
     - 成功時は ``OutputLocation`` から JSON を取得して
-      ``output_dir/{stem}.json`` に保存し、全結果 (成功/失敗/タイムアウト) を
-      ``process_log.jsonl`` に 1 行 1 レコードで追記する
+      ``output_dir/{原本ファイル名}.json`` に保存する。原本ファイル名は
+      コンストラクタ引数 ``local_to_original`` (ローカル basename → 原本)
+      経由で解決し、Office 形式は変換前の Office 名 (``deck.pptx``)、
+      ネイティブ PDF はそのまま (``report.pdf``) になる。全結果
+      (成功/失敗/タイムアウト) を ``process_log.jsonl`` に 1 行 1 レコードで
+      追記する
 """
 
 from __future__ import annotations
@@ -147,6 +151,7 @@ class AsyncInvoker:
         sagemaker_client: Any | None = None,
         sqs_client: Any | None = None,
         s3_client: Any | None = None,
+        local_to_original: dict[str, str] | None = None,
     ) -> None:
         if not input_prefix.endswith("/"):
             raise ValueError(
@@ -167,6 +172,12 @@ class AsyncInvoker:
         self._sagemaker = sagemaker_client or boto3.client("sagemaker-runtime")
         self._sqs = sqs_client or boto3.client("sqs")
         self._s3 = s3_client or boto3.client("s3")
+        # result-filename-extension-preservation: ローカル basename (変換後 PDF
+        # ``deck.pdf`` 等) → 原本ファイル名 (``deck.pptx`` 等) のマップ。
+        # ``main.py`` (orchestrator) のみが構築し、``_drain_queue`` の persist
+        # パス計算で参照する。Office 形式のみ entry あり、ネイティブ PDF 入力は
+        # ``dict.get(name, name)`` で identity 解決される。
+        self._local_to_original: dict[str, str] = dict(local_to_original or {})
 
     # ------------------------------------------------------------------
     # Task 3.1: S3 ステージング + invoke_endpoint_async
@@ -449,7 +460,9 @@ class AsyncInvoker:
         """1 回 ``_poll_queue`` を実行し、結果を result / in_flight に反映する。
 
         成功通知を受けた場合は ``responseParameters.outputLocation`` から
-        JSON を S3 経由でダウンロードし、``output_dir/{stem}.json`` に保存する。
+        JSON を S3 経由でダウンロードし、``output_dir/{output_filename}.json``
+        に保存する (``output_filename`` は ``self._local_to_original`` 経由で
+        原本ファイル名に解決される。Office 形式以外は identity)。
         ダウンロード失敗は失敗扱いとして ``failed_files`` に積む。
 
         失敗通知を受けた場合は ``failureReason`` を ``failed_files`` と
@@ -489,7 +502,21 @@ class AsyncInvoker:
             output_location = (
                 notif.body.get("responseParameters", {}).get("outputLocation")
             )
-            persisted_path = output_dir / f"{file_stem}.json"
+            # result-filename-extension-preservation R1.1-1.4:
+            # persist パスは原本ファイル名 (拡張子付き) + ".json" を使う。
+            # ``local_to_original`` は Office 形式のみ entry を持ち、ネイティブ
+            # PDF 入力では identity (``file_path.name`` がそのまま返る)。
+            # ``_safe_ident`` (SHA-1) は InferenceId / S3 input key 用途のみ。
+            # ``file_path`` が None になる経路は本実装上存在しないが、防御的に
+            # ``file_stem`` フォールバックを残す (DDB 反映が走らないため
+            # ファイル名衝突は問題にならない)。
+            if file_path is not None:
+                output_filename = self._local_to_original.get(
+                    file_path.name, file_path.name
+                )
+            else:
+                output_filename = file_stem
+            persisted_path = output_dir / f"{output_filename}.json"
             try:
                 if not isinstance(output_location, str) or not output_location:
                     raise ValueError(

--- a/lambda/batch-runner/main.py
+++ b/lambda/batch-runner/main.py
@@ -46,7 +46,12 @@ import boto3
 
 from batch_store import apply_process_log, finalize_batch_status
 from control_table import delete_heartbeat, register_heartbeat
-from office_converter import ConvertFailure, convert_office_files, is_office_format
+from office_converter import (
+    ConvertFailure,
+    build_filename_maps,
+    convert_office_files,
+    is_office_format,
+)
 from process_log_reader import read_process_log
 from runner import generate_all_visualizations, run_async_batch
 from s3_sync import download_inputs, upload_outputs
@@ -194,11 +199,17 @@ def run(settings: BatchRunnerSettings) -> int:
         # 3.5. Office → PDF 変換 (PDF only バッチでは早期 skip → R7.1)
         # downloaded は S3 key の list なので Path で basename を取り判定する。
         office_files_present = any(is_office_format(Path(k).name) for k in downloaded)
-        # Bug 001: 変換成功時 yomitoku-client は変換後 PDF (例: deck.pdf) を
-        # process_log.jsonl に書くが、API が seed した DDB FILE PK は原本名
-        # (例: deck.pptx)。下記 map を apply_process_log に渡すことで PK lookup
-        # 時に PDF 名 → 原本名へ書き戻し、phantom FILE 行を防ぐ。
-        pdf_to_original: dict[str, str] = {}
+        # フィルナム双方向マップ (result-filename-extension-preservation):
+        #   local_to_original: {変換後 PDF basename: 原本 Office filename}
+        #     例 {"deck.pdf": "deck.pptx"} — async_invoker で persist パス命名と
+        #     apply_process_log の DDB FILE PK lookup (Bug 001 互換維持) に使用
+        #   original_to_local: {原本 Office filename: 変換後 PDF basename}
+        #     例 {"deck.pptx": "deck.pdf"} — runner で JSON → ローカル PDF 逆引きに使用
+        # 両 map は ``office_converter.build_filename_maps`` で 1 箇所 SSOT 構築
+        # (案 A 採用、Drift 防止)。PDF only バッチでは両 map とも空 dict のままで、
+        # 下流は ``dict.get(name, name)`` で identity 解決される (R5.3 維持)。
+        local_to_original: dict[str, str] = {}
+        original_to_local: dict[str, str] = {}
         if office_files_present:
             convert_result = convert_office_files(
                 input_dir,
@@ -214,11 +225,11 @@ def run(settings: BatchRunnerSettings) -> int:
                     "converted_failed": len(convert_result.failed),
                 },
             )
-            # 変換成功 1 件 = 変換後 PDF の basename → 原本 Office ファイル basename
-            # の写像。``apply_process_log`` がこのマップを使って DDB FILE PK lookup
-            # を原本名に正規化する。
-            for cf in convert_result.succeeded:
-                pdf_to_original[cf.pdf_path.name] = cf.original_path.name
+            # 双方向マップを 1 箇所で原子的に構築 (Drift 防止 / 案 A)。
+            # ``apply_process_log`` の引数名 ``converted_filename_map`` は
+            # office-format-ingestion 由来で維持しつつ、value だけ
+            # ``pdf_to_original`` (旧名) → ``local_to_original`` (新名) に置換。
+            local_to_original, original_to_local = build_filename_maps(convert_result)
             # 変換失敗を process_log.jsonl に追記 (run_async_batch より先に書く)。
             # 成功・失敗いずれも office_converter 側で原本がローカル削除されるため
             # input_dir には変換後 PDF + 元から PDF だったファイルのみが残る
@@ -234,6 +245,7 @@ def run(settings: BatchRunnerSettings) -> int:
                 output_dir=str(output_dir),
                 log_path=str(log_path),
                 deadline_seconds=float(settings.batch_max_duration_sec),
+                local_to_original=local_to_original,
             )
         )
         logger.info(
@@ -251,6 +263,7 @@ def run(settings: BatchRunnerSettings) -> int:
             generate_all_visualizations(
                 input_dir=str(input_dir),
                 output_dir=str(output_dir),
+                original_to_local=original_to_local,
             )
         except Exception:  # noqa: BLE001 — 非致命
             logger.exception(
@@ -295,7 +308,10 @@ def run(settings: BatchRunnerSettings) -> int:
             table=batch_table,
             batch_job_id=settings.batch_job_id,
             entries=entries,
-            converted_filename_map=pdf_to_original,
+            # 引数名 ``converted_filename_map`` は office-format-ingestion 由来で
+            # 維持 (Bug 001 互換); value のみ ``pdf_to_original`` (旧名) →
+            # ``local_to_original`` (新名) に置き換え。
+            converted_filename_map=local_to_original,
         )
 
         # 8. META.status を最終状態に遷移

--- a/lambda/batch-runner/office_converter.py
+++ b/lambda/batch-runner/office_converter.py
@@ -392,3 +392,47 @@ def convert_office_files(
                 failed.append(outcome)
 
     return ConvertResult(succeeded=succeeded, failed=failed)
+
+
+# ---------------------------------------------------------------------------
+# Filename map ヘルパ (Single Source of Truth: 案 A)
+# ---------------------------------------------------------------------------
+
+
+def build_filename_maps(
+    convert_result: ConvertResult,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """変換結果から双方向ファイル名マップを構築する (Single Source of Truth)。
+
+    `result-filename-extension-preservation` design > Components > main.py
+    Implementation Notes (Drift 防止 - 案 A) に基づく。`main.py` 側で双方向 map を
+    個別構築すると将来の保守者が片方だけ更新するリスク (`office-format-ingestion`
+    Bug 001 と同種) があるため、両 map を 1 箇所で原子的に構築する。
+
+    引数:
+        convert_result: `convert_office_files` の戻り値。`succeeded` の各
+            `ConvertedFile(original_path, pdf_path)` から filename basename を抽出する。
+
+    Returns:
+        `(local_to_original, original_to_local)`:
+            - `local_to_original`: `{converted_pdf_basename: original_office_filename}`
+              例: `{"deck.pdf": "deck.pptx"}`
+            - `original_to_local`: `{original_office_filename: converted_pdf_basename}`
+              例: `{"deck.pptx": "deck.pdf"}`
+
+        両 map は完全な逆引き関係 (entry 数同一、`local_to_original[v] == k for k, v
+        in original_to_local.items()`)。`convert_result.succeeded` が空 (ネイティブ
+        PDF のみのバッチ) であれば両 map とも空 dict (`{}`) を返す。
+
+    Postconditions:
+        - `len(local_to_original) == len(original_to_local) == len(convert_result.succeeded)`
+        - `all(local_to_original[v] == k for k, v in original_to_local.items())`
+    """
+    local_to_original: dict[str, str] = {}
+    original_to_local: dict[str, str] = {}
+    for converted in convert_result.succeeded:
+        original_name = converted.original_path.name
+        pdf_name = converted.pdf_path.name
+        local_to_original[pdf_name] = original_name
+        original_to_local[original_name] = pdf_name
+    return local_to_original, original_to_local

--- a/lambda/batch-runner/runner.py
+++ b/lambda/batch-runner/runner.py
@@ -43,6 +43,7 @@ async def run_async_batch(
     output_dir: str | Path,
     log_path: str | Path,
     deadline_seconds: float | None = None,
+    local_to_original: dict[str, str] | None = None,
 ) -> BatchResult:
     """Async Inference 経路でバッチを実行し、``BatchResult`` を返す。
 
@@ -50,6 +51,9 @@ async def run_async_batch(
       (末尾スラッシュ必須: ``AsyncInvoker.__init__`` が検証)
     - ``deadline_seconds`` を省略した場合は
       ``settings.batch_max_duration_sec`` を採用する
+    - ``local_to_original``: ローカル PDF basename → 原本ファイル名のマップ
+      (省略時は identity)。Office 形式で ``deck.pdf`` (変換後) → ``deck.pptx``
+      (原本) のような書き戻しに使用。``AsyncInvoker`` にそのまま転送する。
     - 呼び出し側 (Fargate main) は ``BatchResult.succeeded_files`` /
       ``failed_files`` / ``in_flight_timeout`` を DDB 反映に利用する
     """
@@ -73,6 +77,7 @@ async def run_async_batch(
         success_queue_url=settings.success_queue_url,
         failure_queue_url=settings.failure_queue_url,
         max_concurrent=settings.async_max_concurrent,
+        local_to_original=local_to_original,
     )
 
     deadline = float(

--- a/lambda/batch-runner/runner.py
+++ b/lambda/batch-runner/runner.py
@@ -152,13 +152,30 @@ def _generate_for_single_file(
 
 
 def generate_all_visualizations(
-    *, input_dir: str, output_dir: str
+    *,
+    input_dir: str,
+    output_dir: str,
+    original_to_local: dict[str, str] | None = None,
 ) -> dict[str, list[str]]:
-    """``output_dir/*.json`` に対して ``input_dir/{basename}.pdf`` の可視化を生成する。
+    """``output_dir/*.json`` に対して ``input_dir/{local_pdf_basename}.pdf`` の可視化を生成する。
+
+    新命名規約 (``{原本ファイル名}.json``) に対応するため、JSON ファイル名から
+    ``.json`` を 1 段だけ剥がして ``original_input_name`` を得る。Office 形式の
+    場合、``original_to_local`` map (例: ``{"deck.pptx": "deck.pdf"}``) で
+    ローカル PDF basename に逆引き解決する。ネイティブ PDF は identity 解決
+    (``report.pdf.json`` → ``report.pdf``)。
+
+    Args:
+        input_dir: ローカル PDF が並置されているディレクトリ。
+        output_dir: メイン JSON および可視化 JPEG を出力するディレクトリ。
+        original_to_local: Office 形式の ``{原本ファイル名: ローカル PDF basename}``
+            マッピング。``None`` または空 dict は identity 解決と等価
+            (ネイティブ PDF のみのバッチで使用)。
 
     Returns:
-        ``{basename: [error_messages...]}`` — エラーがあったファイルのみ記録。
-        空 dict なら全件完全成功。
+        ``{original_input_name: [error_messages...]}`` — エラーがあったファイル
+        のみ記録。空 dict なら全件完全成功。lookup 失敗は致命ではなく silent
+        skip + warning ログとして扱う。
     """
     errors_per_file: dict[str, list[str]] = {}
     out_path = Path(output_dir)
@@ -166,17 +183,22 @@ def generate_all_visualizations(
     if not out_path.exists():
         return errors_per_file
 
+    lookup = original_to_local or {}
     for json_file in sorted(out_path.glob("*.json")):
-        basename = json_file.stem
-        pdf_path = in_path / f"{basename}.pdf"
+        # ``.json`` を 1 段だけ剥がす (新命名規約: ``{原本ファイル名}.json``)。
+        original_input_name = json_file.name[: -len(".json")]
+        local_pdf_basename = lookup.get(original_input_name, original_input_name)
+        pdf_path = in_path / local_pdf_basename
         if not pdf_path.exists():
-            errors_per_file[basename] = [f"input PDF not found: {pdf_path.name}"]
+            errors_per_file[original_input_name] = [
+                f"local PDF not found: {local_pdf_basename}"
+            ]
             continue
         errs = _generate_for_single_file(
             json_path=json_file, pdf_path=pdf_path, out_dir=out_path
         )
         if errs:
-            errors_per_file[basename] = errs
+            errors_per_file[original_input_name] = errs
 
     if errors_per_file:
         logger.warning(

--- a/lambda/batch-runner/tests/test_async_invoker.py
+++ b/lambda/batch-runner/tests/test_async_invoker.py
@@ -865,7 +865,7 @@ def test_run_batch_persists_output_json_from_output_location(
     full_aws_env, tmp_path: Path
 ) -> None:
     """成功通知を受けたら OutputLocation から JSON をダウンロードし
-    `output_dir/{stem}.json` に保存する。"""
+    `output_dir/{原本ファイル名}.json` に保存する。"""
     env = full_aws_env
     invoker = _make_invoker(env, max_concurrent=2)
 
@@ -897,7 +897,7 @@ def test_run_batch_persists_output_json_from_output_location(
 
     assert result.succeeded_files == ["ok"]
     # output JSON がローカルに書き出される
-    persisted = output_dir / "ok.json"
+    persisted = output_dir / "ok.pdf.json"
     assert persisted.exists(), f"output JSON not persisted: {persisted}"
     body = json.loads(persisted.read_text(encoding="utf-8"))
     assert body == {"pages": [{"idx": 0}], "stem": "ok"}
@@ -952,7 +952,7 @@ def test_run_batch_appends_process_log_for_success_and_failure(
     assert len(by_success[False]) == 1
     success_row = by_success[True][0]
     assert Path(success_row["file_path"]).name == "ok.pdf"
-    assert success_row["output_path"].endswith("ok.json")
+    assert success_row["output_path"].endswith("ok.pdf.json")
     assert success_row.get("error") in (None, "")
     failure_row = by_success[False][0]
     assert Path(failure_row["file_path"]).name == "bad.pdf"
@@ -1116,3 +1116,242 @@ def test_run_batch_records_in_flight_timeout_to_process_log(
         and "timeout" in (r.get("error") or "").lower()
         for r in records
     )
+
+
+# --------------------------------------------------------------------------
+# result-filename-extension-preservation Task 2.1:
+# JSON persist 命名規約を {file_stem}.json から {原本ファイル名}.json に変更
+#
+# - PDF 入力 (R1.1): report.pdf → output_dir/report.pdf.json
+# - Office 入力 (R1.2, R1.3): local deck.pdf + local_to_original={deck.pdf: deck.pptx}
+#                              → output_dir/deck.pptx.json (変換後 PDF 名でなく原本 Office 名)
+# - 非 ASCII / サニタイズ済 filename (R1.4): persist パスに _safe_ident SHA-1 16 文字が
+#                                               含まれず、サニタイズ済 filename + ".json" になる
+# --------------------------------------------------------------------------
+
+
+class TestNewNamingConvention:
+    """JSON persist パスが ``{file_stem}.json`` から ``{原本ファイル名}.json`` に変わる。
+
+    設計参照: design.md > Components > async_invoker.AsyncInvoker > Service Interface,
+    Implementation Notes (R1.1, R1.2, R1.3, R1.4)。
+    """
+
+    def test_pdf_input_persists_with_full_filename_including_extension(
+        self, full_aws_env, tmp_path: Path
+    ) -> None:
+        """PDF 入力 ``report.pdf`` → ``output_dir/report.pdf.json`` で保存される (R1.1).
+
+        旧仕様 (``{stem}.json`` = ``report.json``) ではなく、原本拡張子を含む
+        ``report.pdf.json`` で保存されることを assert する。
+        """
+        env = full_aws_env
+        invoker = _make_invoker(env, max_concurrent=1)
+
+        file_pdf = _write_input(tmp_path, "report.pdf")
+        # outputLocation 取得用ダミー: success body の outputLocation は
+        # ``s3://{BUCKET}/batches/_async/outputs/{stem}.out`` 形式
+        # (``_success_body`` ヘルパが ``inference_id.split(':')[-1]`` から組み立てる)。
+        _put_dummy_output(env["s3"], "report", payload={"pages": [{"idx": 0}]})
+        env["sqs"].send_message(
+            QueueUrl=env["success_url"],
+            MessageBody=_sns_wrap(_success_body(f"{BATCH_JOB_ID}:report")),
+        )
+
+        stubber = env["stubber"]
+        stubber.add_response(
+            "invoke_endpoint_async",
+            {"InferenceId": f"{BATCH_JOB_ID}:report", "OutputLocation": "s3://x/y"},
+        )
+        stubber.activate()
+
+        output_dir = tmp_path / "out"
+        log_path = output_dir / "process_log.jsonl"
+        result = asyncio.run(
+            invoker.run_batch(
+                batch_job_id=BATCH_JOB_ID,
+                input_files=[file_pdf],
+                output_dir=output_dir,
+                log_path=log_path,
+                deadline_seconds=30.0,
+            )
+        )
+
+        assert len(result.succeeded_files) == 1
+        # 新仕様: 原本ファイル名 (拡張子付き) + ".json"
+        persisted = output_dir / "report.pdf.json"
+        assert persisted.exists(), (
+            f"output JSON should be persisted at new convention path: {persisted}"
+        )
+        # 旧仕様 ({stem}.json) ではないこと
+        assert not (output_dir / "report.json").exists(), (
+            "old naming convention {stem}.json should not be used"
+        )
+        # process_log.jsonl の output_path も新仕様に追従する (R1.5 の前提)
+        records = _read_process_log(log_path)
+        success_rows = [r for r in records if r.get("success") is True]
+        assert len(success_rows) == 1
+        assert success_rows[0]["output_path"].endswith("report.pdf.json")
+
+    def test_office_input_uses_original_office_filename_via_local_to_original(
+        self, full_aws_env, tmp_path: Path
+    ) -> None:
+        """Office 形式 (R1.2, R1.3): ローカル ``deck.pdf`` + map → ``deck.pptx.json``.
+
+        ``local_to_original={"deck.pdf": "deck.pptx"}`` を渡した場合、
+        SageMaker には変換後 PDF (``deck.pdf``) が送られるが、JSON persist
+        パスは原本 Office 名 (``deck.pptx``) + ``.json`` になる。
+        """
+        env = full_aws_env
+        invoker = AsyncInvoker(
+            endpoint_name="yomitoku-async",
+            input_bucket=BUCKET,
+            input_prefix=INPUT_PREFIX,
+            output_bucket=BUCKET,
+            success_queue_url=env["success_url"],
+            failure_queue_url=env["failure_url"],
+            max_concurrent=1,
+            poll_wait_seconds=0,
+            sagemaker_client=env["sagemaker"],
+            sqs_client=env["sqs"],
+            s3_client=env["s3"],
+            local_to_original={"deck.pdf": "deck.pptx"},
+        )
+
+        file_pdf = _write_input(tmp_path, "deck.pdf")
+        _put_dummy_output(env["s3"], "deck", payload={"pages": []})
+        env["sqs"].send_message(
+            QueueUrl=env["success_url"],
+            MessageBody=_sns_wrap(_success_body(f"{BATCH_JOB_ID}:deck")),
+        )
+
+        stubber = env["stubber"]
+        stubber.add_response(
+            "invoke_endpoint_async",
+            {"InferenceId": f"{BATCH_JOB_ID}:deck", "OutputLocation": "s3://x/y"},
+        )
+        stubber.activate()
+
+        output_dir = tmp_path / "out"
+        log_path = output_dir / "process_log.jsonl"
+        result = asyncio.run(
+            invoker.run_batch(
+                batch_job_id=BATCH_JOB_ID,
+                input_files=[file_pdf],
+                output_dir=output_dir,
+                log_path=log_path,
+                deadline_seconds=30.0,
+            )
+        )
+
+        assert len(result.succeeded_files) == 1
+        # 原本 Office 名 + ".json" (変換後 PDF 名でなく)
+        persisted = output_dir / "deck.pptx.json"
+        assert persisted.exists(), (
+            f"output JSON should use original Office filename: {persisted}"
+        )
+        assert not (output_dir / "deck.pdf.json").exists(), (
+            "should not use converted PDF basename for persist path"
+        )
+        assert not (output_dir / "deck.json").exists(), (
+            "should not use stem-only naming"
+        )
+        # process_log の output_path も同様
+        records = _read_process_log(log_path)
+        success_rows = [r for r in records if r.get("success") is True]
+        assert len(success_rows) == 1
+        assert success_rows[0]["output_path"].endswith("deck.pptx.json")
+
+    def test_non_ascii_filename_persist_path_excludes_safe_ident_hash(
+        self, full_aws_env, tmp_path: Path
+    ) -> None:
+        """非 ASCII filename: persist パスに ``_safe_ident`` SHA-1 16 文字が **含まれない** (R1.4).
+
+        - InferenceId / S3 input key は SHA-1 で安全化されるが、
+        - persist パスは原本 (= サニタイズ済) filename + ``.json`` をそのまま使う。
+
+        本テストでは file_path.name = "報告書.pdf" を渡し、
+        persist パスが ``output_dir / "報告書.pdf.json"`` であり、
+        ``_safe_ident("報告書")`` の 16 文字 SHA-1 ハッシュ文字列が
+        パスに含まれないことを確認する。
+        """
+        env = full_aws_env
+        invoker = _make_invoker(env, max_concurrent=1)
+
+        non_ascii_name = "報告書.pdf"
+        file_path = tmp_path / non_ascii_name
+        file_path.write_bytes(b"%PDF-1.4\n%stub\n")
+
+        # InferenceId は _safe_ident(stem) を使うため、stem = "報告書" → SHA-1 16 文字
+        from async_invoker import _safe_ident  # type: ignore
+
+        safe_stem = _safe_ident("報告書")
+        # 16 文字の SHA-1 hex であることを sanity check (テスト前提の確認)
+        assert len(safe_stem) == 16
+        assert all(c in "0123456789abcdef" for c in safe_stem)
+        inference_id = f"{BATCH_JOB_ID}:{safe_stem}"
+
+        # success body 構築 (outputLocation は safe_stem を使う、_success_body と同形式)
+        success_body = {
+            "awsRegion": REGION,
+            "invocationStatus": "Completed",
+            "requestParameters": {
+                "endpointName": "yomitoku-async",
+                "inputLocation": (
+                    f"s3://{BUCKET}/batches/_async/inputs/{BATCH_JOB_ID}/{safe_stem}.pdf"
+                ),
+            },
+            "responseParameters": {
+                "contentType": "application/json",
+                "outputLocation": (
+                    f"s3://{BUCKET}/batches/_async/outputs/{safe_stem}.out"
+                ),
+            },
+            "inferenceId": inference_id,
+        }
+        env["s3"].put_object(
+            Bucket=BUCKET,
+            Key=f"batches/_async/outputs/{safe_stem}.out",
+            Body=json.dumps({"pages": []}).encode("utf-8"),
+            ContentType="application/json",
+        )
+        env["sqs"].send_message(
+            QueueUrl=env["success_url"],
+            MessageBody=_sns_wrap(success_body),
+        )
+
+        stubber = env["stubber"]
+        stubber.add_response(
+            "invoke_endpoint_async",
+            {"InferenceId": inference_id, "OutputLocation": "s3://x/y"},
+        )
+        stubber.activate()
+
+        output_dir = tmp_path / "out"
+        log_path = output_dir / "process_log.jsonl"
+        result = asyncio.run(
+            invoker.run_batch(
+                batch_job_id=BATCH_JOB_ID,
+                input_files=[file_path],
+                output_dir=output_dir,
+                log_path=log_path,
+                deadline_seconds=30.0,
+            )
+        )
+
+        assert len(result.succeeded_files) == 1
+        # persist パスは原本 (非 ASCII) filename + ".json"
+        persisted = output_dir / "報告書.pdf.json"
+        assert persisted.exists(), (
+            f"persist path should use sanitized original filename: {persisted}"
+        )
+        # SHA-1 16 文字ハッシュ文字列が persist パスに **含まれない**
+        persisted_str = str(persisted)
+        assert safe_stem not in persisted_str, (
+            f"persist path must not contain _safe_ident SHA-1 hash "
+            f"({safe_stem!r}); actual path: {persisted_str!r}"
+        )
+        # 旧仕様パス (SHA-1 stem + .json) も存在しないこと
+        assert not (output_dir / f"{safe_stem}.json").exists(), (
+            "should not persist using SHA-1 hashed stem path"
+        )

--- a/lambda/batch-runner/tests/test_batch_store.py
+++ b/lambda/batch-runner/tests/test_batch_store.py
@@ -101,7 +101,7 @@ class TestUpdateFileResult:
                 status="COMPLETED",
                 dpi=200,
                 processing_time_ms=5432,
-                result_key=f"batches/{BATCH_ID}/output/a.json",
+                result_key=f"batches/{BATCH_ID}/output/a.pdf.json",
             )
             assert updated is True
 
@@ -113,7 +113,7 @@ class TestUpdateFileResult:
             assert item["status"] == "COMPLETED"
             assert int(item["dpi"]) == 200
             assert int(item["processingTimeMs"]) == 5432
-            assert item["resultKey"] == f"batches/{BATCH_ID}/output/a.json"
+            assert item["resultKey"] == f"batches/{BATCH_ID}/output/a.pdf.json"
 
     def test_marks_file_failed_with_error_message(self):
         with mock_aws():
@@ -184,7 +184,7 @@ class TestUpdateFileResult:
                 table=table, batch_job_id=BATCH_ID,
                 file_key=f"batches/{BATCH_ID}/input/ghost.pdf",
                 status="COMPLETED",
-                result_key=f"batches/{BATCH_ID}/output/ghost.json",
+                result_key=f"batches/{BATCH_ID}/output/ghost.pdf.json",
             )
             # 既存行が無いため ConditionalCheckFailedException → False
             assert updated is False
@@ -310,7 +310,7 @@ class TestApplyProcessLog:
                 ProcessLogEntry(
                     file_path="/tmp/input/a.pdf", filename="a.pdf",
                     success=True, dpi=200,
-                    output_path="/tmp/output/a.json",
+                    output_path="/tmp/output/a.pdf.json",
                 ),
                 ProcessLogEntry(
                     file_path="/tmp/input/b.pdf", filename="b.pdf",
@@ -319,7 +319,7 @@ class TestApplyProcessLog:
                 ProcessLogEntry(
                     file_path="/tmp/input/c.pdf", filename="c.pdf",
                     success=True, dpi=200,
-                    output_path="/tmp/output/c.json",
+                    output_path="/tmp/output/c.pdf.json",
                 ),
             ]
             totals = batch_store.apply_process_log(
@@ -332,7 +332,7 @@ class TestApplyProcessLog:
                 "SK": f"FILE#batches/{BATCH_ID}/input/a.pdf",
             })["Item"]
             assert a_item["status"] == "COMPLETED"
-            assert a_item["resultKey"] == f"batches/{BATCH_ID}/output/a.json"
+            assert a_item["resultKey"] == f"batches/{BATCH_ID}/output/a.pdf.json"
             b_item = table.get_item(Key={
                 "PK": f"BATCH#{BATCH_ID}",
                 "SK": f"FILE#batches/{BATCH_ID}/input/b.pdf",
@@ -370,7 +370,7 @@ class TestApplyProcessLog:
                 ProcessLogEntry(
                     file_path="/tmp/input/ok.pdf", filename="ok.pdf",
                     success=True, dpi=200,
-                    output_path="/tmp/output/ok.json",
+                    output_path="/tmp/output/ok.pdf.json",
                 ),
             ]
             totals = batch_store.apply_process_log(
@@ -426,13 +426,15 @@ class TestApplyProcessLogConvertedFilenameMap:
             import batch_store
 
             entries = [
-                # process_log says deck.pdf because soffice converted it
+                # process_log says deck.pdf (= post-conversion local file) but
+                # async_invoker は local_to_original 経由で原本 deck.pptx 名で
+                # JSON を書く。よって output_path は deck.pptx.json (新仕様 R1.2)
                 ProcessLogEntry(
                     file_path="/tmp/input/deck.pdf",
                     filename="deck.pdf",
                     success=True,
                     dpi=200,
-                    output_path="/tmp/output/deck.json",
+                    output_path="/tmp/output/deck.pptx.json",
                 ),
             ]
             totals = batch_store.apply_process_log(
@@ -449,10 +451,11 @@ class TestApplyProcessLogConvertedFilenameMap:
                 "SK": f"FILE#batches/{BATCH_ID}/input/deck.pptx",
             })["Item"]
             assert deck_pptx["status"] == "COMPLETED"
-            # resultKey points at deck.json (the actual S3 output path,
-            # which is .pdf-stem-based — not rewritten)
+            # 新仕様 (R1.2): resultKey は原本 Office 名 (`deck.pptx.json`) を指す。
+            # 変換後 PDF basename ではなく、async_invoker で原本ファイル名を
+            # local_to_original 経由で書き戻した結果。
             assert deck_pptx["resultKey"] == (
-                f"batches/{BATCH_ID}/output/deck.json"
+                f"batches/{BATCH_ID}/output/deck.pptx.json"
             )
 
             # No phantom deck.pdf row
@@ -480,7 +483,7 @@ class TestApplyProcessLogConvertedFilenameMap:
                     filename="report.pdf",
                     success=True,
                     dpi=200,
-                    output_path="/tmp/output/report.json",
+                    output_path="/tmp/output/report.pdf.json",
                 ),
             ]
             totals = batch_store.apply_process_log(
@@ -512,7 +515,7 @@ class TestApplyProcessLogConvertedFilenameMap:
                     filename="a.pdf",
                     success=True,
                     dpi=200,
-                    output_path="/tmp/output/a.json",
+                    output_path="/tmp/output/a.pdf.json",
                 ),
             ]
             # No converted_filename_map argument
@@ -548,20 +551,22 @@ class TestApplyProcessLogConvertedFilenameMap:
                     error="encrypted",
                     error_category="CONVERSION_FAILED",
                 ),
-                # OCR success rows from yomitoku-client
+                # OCR success rows from async_invoker (新仕様 {原本名}.json):
+                # report.pdf は native PDF → report.pdf.json
+                # deck.pdf は変換後 → 原本 deck.pptx 名で deck.pptx.json
                 ProcessLogEntry(
                     file_path="/tmp/input/report.pdf",
                     filename="report.pdf",
                     success=True,
                     dpi=200,
-                    output_path="/tmp/output/report.json",
+                    output_path="/tmp/output/report.pdf.json",
                 ),
                 ProcessLogEntry(
-                    file_path="/tmp/input/deck.pdf",  # post-conversion
+                    file_path="/tmp/input/deck.pdf",  # post-conversion local file
                     filename="deck.pdf",
                     success=True,
                     dpi=200,
-                    output_path="/tmp/output/deck.json",
+                    output_path="/tmp/output/deck.pptx.json",
                 ),
             ]
             totals = batch_store.apply_process_log(
@@ -585,7 +590,7 @@ class TestApplyProcessLogConvertedFilenameMap:
             })["Item"]
             assert deck_pptx_item["status"] == "COMPLETED"
             assert deck_pptx_item["resultKey"] == (
-                f"batches/{BATCH_ID}/output/deck.json"
+                f"batches/{BATCH_ID}/output/deck.pptx.json"
             )
 
             broken_item = table.get_item(Key={
@@ -601,6 +606,188 @@ class TestApplyProcessLogConvertedFilenameMap:
                 "SK": f"FILE#batches/{BATCH_ID}/input/deck.pdf",
             })
             assert "Item" not in phantom
+
+
+class TestResultKeyExtensionPreservation:
+    """Task 4.1 (a): result-filename-extension-preservation の resultKey 全形式検証。
+
+    PDF / PPTX / DOCX / XLSX + 変換失敗 PPTX が混在するバッチで、各 FILE の
+    resultKey が新仕様 ``{原本ファイル名}.json`` で書き込まれることを assert。
+    変換失敗ファイルは resultKey 未設定 + errorCategory=CONVERSION_FAILED を確認
+    (R1.1, R1.2, R1.3, R1.5, R3.1)。
+    """
+
+    def test_all_office_formats_get_extension_preserved_result_key(self):
+        from process_log_reader import ProcessLogEntry
+
+        with mock_aws():
+            table = _create_batch_table()
+            _seed_batch(table, BATCH_ID, [
+                "report.pdf",   # native PDF
+                "deck.pptx",    # PPTX → 変換成功
+                "memo.docx",    # DOCX → 変換成功
+                "sheet.xlsx",   # XLSX → 変換成功
+                "broken.pptx",  # PPTX → 変換失敗
+            ])
+            import batch_store
+
+            entries = [
+                ProcessLogEntry(
+                    file_path="/tmp/input/broken.pptx",
+                    filename="broken.pptx",
+                    success=False,
+                    error="encrypted PPTX",
+                    error_category="CONVERSION_FAILED",
+                ),
+                ProcessLogEntry(
+                    file_path="/tmp/input/report.pdf",
+                    filename="report.pdf",
+                    success=True, dpi=200,
+                    output_path="/tmp/output/report.pdf.json",
+                ),
+                ProcessLogEntry(
+                    file_path="/tmp/input/deck.pdf",
+                    filename="deck.pdf",
+                    success=True, dpi=200,
+                    output_path="/tmp/output/deck.pptx.json",
+                ),
+                ProcessLogEntry(
+                    file_path="/tmp/input/memo.pdf",
+                    filename="memo.pdf",
+                    success=True, dpi=200,
+                    output_path="/tmp/output/memo.docx.json",
+                ),
+                ProcessLogEntry(
+                    file_path="/tmp/input/sheet.pdf",
+                    filename="sheet.pdf",
+                    success=True, dpi=200,
+                    output_path="/tmp/output/sheet.xlsx.json",
+                ),
+            ]
+            totals = batch_store.apply_process_log(
+                table=table, batch_job_id=BATCH_ID, entries=entries,
+                converted_filename_map={
+                    "deck.pdf": "deck.pptx",
+                    "memo.pdf": "memo.docx",
+                    "sheet.pdf": "sheet.xlsx",
+                },
+            )
+            assert totals == {"succeeded": 4, "failed": 1, "skipped": 0}
+
+            # 各原本ファイル行で resultKey 値が新仕様であることを assert
+            expected = {
+                "report.pdf": "report.pdf.json",
+                "deck.pptx": "deck.pptx.json",
+                "memo.docx": "memo.docx.json",
+                "sheet.xlsx": "sheet.xlsx.json",
+            }
+            for orig_filename, expected_basename in expected.items():
+                item = table.get_item(Key={
+                    "PK": f"BATCH#{BATCH_ID}",
+                    "SK": f"FILE#batches/{BATCH_ID}/input/{orig_filename}",
+                })["Item"]
+                assert item["status"] == "COMPLETED"
+                assert item["resultKey"] == (
+                    f"batches/{BATCH_ID}/output/{expected_basename}"
+                )
+
+            # 変換失敗 PPTX は resultKey 未設定 + errorCategory=CONVERSION_FAILED
+            broken = table.get_item(Key={
+                "PK": f"BATCH#{BATCH_ID}",
+                "SK": f"FILE#batches/{BATCH_ID}/input/broken.pptx",
+            })["Item"]
+            assert broken["status"] == "FAILED"
+            assert broken["errorCategory"] == "CONVERSION_FAILED"
+            assert "resultKey" not in broken
+
+
+class TestPreExistingResultKeyImmutability:
+    """Task 4.1 (c): R5.1 / R5.2 ガード — 既存バッチ非影響の検証。
+
+    旧フォーマット ``{stem}.json`` の resultKey を持つ既存 FILE 行が、
+    別バッチで新仕様の ``apply_process_log`` を実行したときに、
+    遡及的に書き換えられないことを assert (R5.1: S3 オブジェクト遡及リネーム
+    なし / R5.2: DDB resultKey 値遡及更新なし)。
+    """
+
+    def test_existing_batch_legacy_result_key_unchanged_after_new_batch(self):
+        from process_log_reader import ProcessLogEntry
+
+        legacy_batch_id = "old-batch-001"
+        new_batch_id = "new-batch-002"
+
+        with mock_aws():
+            table = _create_batch_table()
+            # 1. 既存 (旧仕様デプロイ前) のバッチを seed: report.pdf に
+            #    旧フォーマット resultKey が既に書かれている
+            _seed_batch(table, legacy_batch_id, ["report.pdf"])
+            import batch_store
+            batch_store.update_file_result(
+                table=table, batch_job_id=legacy_batch_id,
+                file_key=f"batches/{legacy_batch_id}/input/report.pdf",
+                status="COMPLETED",
+                dpi=200,
+                processing_time_ms=1000,
+                # legacy-on-purpose: R5.1/R5.2 検証用の旧フォーマット (stem ベース)
+                # 値を意図的に DDB に書き込み、新仕様 deploy 後の遡及更新が
+                # 起きないことを確認する。本リテラルは契約ガードの除外対象。
+                result_key=f"batches/{legacy_batch_id}/output/report.json",  # legacy-on-purpose
+            )
+
+            # 2. 別の新規バッチを seed して新仕様で apply_process_log を実行
+            _seed_batch(table, new_batch_id, ["report.pdf"])
+            entries = [
+                ProcessLogEntry(
+                    file_path="/tmp/input/report.pdf",
+                    filename="report.pdf",
+                    success=True, dpi=200,
+                    output_path="/tmp/output/report.pdf.json",
+                ),
+            ]
+            totals = batch_store.apply_process_log(
+                table=table, batch_job_id=new_batch_id, entries=entries,
+            )
+            assert totals == {"succeeded": 1, "failed": 0, "skipped": 0}
+
+            # 3. 既存バッチの resultKey 値が unchanged (= 旧フォーマットのまま) を assert
+            legacy = table.get_item(Key={
+                "PK": f"BATCH#{legacy_batch_id}",
+                "SK": f"FILE#batches/{legacy_batch_id}/input/report.pdf",
+            })["Item"]
+            assert legacy["resultKey"] == (
+                f"batches/{legacy_batch_id}/output/report.json"  # legacy-on-purpose
+            ), (
+                "R5.2 違反: 既存バッチの resultKey が遡及更新された "
+                f"(現値: {legacy.get('resultKey')})"
+            )
+
+            # 4. 新規バッチは新仕様で書かれている
+            new = table.get_item(Key={
+                "PK": f"BATCH#{new_batch_id}",
+                "SK": f"FILE#batches/{new_batch_id}/input/report.pdf",
+            })["Item"]
+            assert new["resultKey"] == (
+                f"batches/{new_batch_id}/output/report.pdf.json"
+            )
+
+
+class TestPendingProcessingFilesHaveNoResultKey:
+    """Task 4.1 / R3.3: PENDING / PROCESSING 状態の FILE で resultKey 属性が
+    存在しないことを assert。``_seed_batch`` 直後の PENDING 行は resultKey が
+    未設定 (optional default 動作) であることを契約としてテストする。
+    """
+
+    def test_pending_file_has_no_result_key_attribute(self):
+        with mock_aws():
+            table = _create_batch_table()
+            _seed_batch(table, BATCH_ID, ["pending.pdf"])
+
+            item = table.get_item(Key={
+                "PK": f"BATCH#{BATCH_ID}",
+                "SK": f"FILE#batches/{BATCH_ID}/input/pending.pdf",
+            })["Item"]
+            assert item["status"] == "PENDING"
+            assert "resultKey" not in item
 
 
 class TestFinalizeBatchStatus:

--- a/lambda/batch-runner/tests/test_main.py
+++ b/lambda/batch-runner/tests/test_main.py
@@ -415,6 +415,171 @@ class TestOfficeConversionPhase:
         assert called["delete_objects"] == 0
 
 
+class TestFilenameMapPropagation:
+    """Task 3.1: main.py が local_to_original / original_to_local を下流 3 箇所に注入する。
+
+    Design.md > Components > main.py orchestrator > Implementation Notes (案 A):
+        - `office_converter.build_filename_maps(convert_result)` で両 map を 1 箇所で
+          原子的に構築する (Drift 防止 / SSOT)
+        - `run_async_batch(local_to_original=local_to_original)`
+        - `generate_all_visualizations(original_to_local=original_to_local)`
+        - `apply_process_log(converted_filename_map=local_to_original)` (引数名は維持、
+          value のみ pdf_to_original → local_to_original にリネーム / Bug 001 互換維持)
+
+    PDF only バッチ (`is_office_format` がいずれも False) では convert_office_files が
+    呼ばれず、両 map は空 dict のまま下流に渡され identity 解決される (R5.3 維持)。
+    """
+
+    def test_pdf_only_batch_passes_empty_maps_to_downstream(
+        self, monkeypatch: pytest.MonkeyPatch, patched_main
+    ):
+        """PDF only バッチでは local_to_original / original_to_local とも空 dict が
+        run_async_batch / generate_all_visualizations / apply_process_log に届く。"""
+        main_module, rec = patched_main
+        # 既定の patched_main は PDF 2 件 (a.pdf, b.pdf) をダウンロードする
+
+        assert main_module.main() == 0
+
+        run_async_kw = next(c for c in rec.calls if c[0] == "run_async_batch")[1]
+        viz_kw = next(c for c in rec.calls if c[0] == "generate_all_visualizations")[1]
+        apply_kw = next(c for c in rec.calls if c[0] == "apply_process_log")[1]
+
+        assert run_async_kw.get("local_to_original") == {}, (
+            "PDF only batch must pass empty local_to_original to run_async_batch"
+        )
+        assert viz_kw.get("original_to_local") == {}, (
+            "PDF only batch must pass empty original_to_local to generate_all_visualizations"
+        )
+        assert apply_kw.get("converted_filename_map") == {}, (
+            "PDF only batch must pass empty converted_filename_map to apply_process_log"
+        )
+
+    def test_mixed_batch_propagates_both_maps_to_three_callsites(
+        self, monkeypatch: pytest.MonkeyPatch, patched_main, tmp_path: Path
+    ):
+        """混在バッチで両 map が各 callsite に届き、互いに逆引き関係である。"""
+        main_module, rec = patched_main
+
+        # downloaded を mixed (PDF + 2 種類の Office) に差し替え
+        monkeypatch.setattr(
+            main_module, "download_inputs",
+            lambda **kw: (
+                rec.record("download_inputs")(**kw),
+                [
+                    "batches/x/input/a.pdf",
+                    "batches/x/input/deck.pptx",
+                    "batches/x/input/report.docx",
+                ],
+            )[1],
+        )
+
+        # convert_office_files: 2 件成功 (deck.pptx → deck.pdf, report.docx → report.pdf)
+        # 1 件変換失敗 (broken.xlsx)
+        broken_path = tmp_path / "input" / "broken.xlsx"
+
+        def _fake_convert(input_dir, **kwargs):
+            rec.calls.append(("convert_office_files", {"input_dir": input_dir, **kwargs}))
+            return SimpleNamespace(
+                succeeded=[
+                    SimpleNamespace(
+                        original_path=Path(input_dir) / "deck.pptx",
+                        pdf_path=Path(input_dir) / "deck.pdf",
+                    ),
+                    SimpleNamespace(
+                        original_path=Path(input_dir) / "report.docx",
+                        pdf_path=Path(input_dir) / "report.pdf",
+                    ),
+                ],
+                failed=[
+                    SimpleNamespace(
+                        original_path=broken_path,
+                        reason="encrypted",
+                        detail="encrypted: broken.xlsx",
+                    )
+                ],
+            )
+
+        monkeypatch.setattr(main_module, "convert_office_files", _fake_convert)
+
+        assert main_module.main() == 0
+
+        run_async_kw = next(c for c in rec.calls if c[0] == "run_async_batch")[1]
+        viz_kw = next(c for c in rec.calls if c[0] == "generate_all_visualizations")[1]
+        apply_kw = next(c for c in rec.calls if c[0] == "apply_process_log")[1]
+
+        expected_local_to_original = {
+            "deck.pdf": "deck.pptx",
+            "report.pdf": "report.docx",
+        }
+        expected_original_to_local = {
+            "deck.pptx": "deck.pdf",
+            "report.docx": "report.pdf",
+        }
+
+        assert run_async_kw.get("local_to_original") == expected_local_to_original, (
+            "run_async_batch must receive local_to_original "
+            "(converted_pdf_basename → original_office_filename)"
+        )
+        assert viz_kw.get("original_to_local") == expected_original_to_local, (
+            "generate_all_visualizations must receive original_to_local "
+            "(original_office_filename → converted_pdf_basename)"
+        )
+        # apply_process_log は引数名 converted_filename_map を維持し、value は
+        # local_to_original を流用 (Bug 001 互換)
+        assert apply_kw.get("converted_filename_map") == expected_local_to_original, (
+            "apply_process_log must receive converted_filename_map=local_to_original "
+            "(arg name preserved, value swapped from pdf_to_original)"
+        )
+
+        # 両 map は完全な逆引き関係であること (Drift 防止 invariant)
+        local_to_original = run_async_kw["local_to_original"]
+        original_to_local = viz_kw["original_to_local"]
+        assert all(
+            local_to_original[v] == k for k, v in original_to_local.items()
+        ), (
+            "local_to_original and original_to_local must be perfect bijection "
+            "(SSOT invariant: build_filename_maps)"
+        )
+
+    def test_mixed_batch_no_office_failures_still_propagates_maps(
+        self, monkeypatch: pytest.MonkeyPatch, patched_main
+    ):
+        """変換失敗 0 件 / 成功 1 件のケースでも map が propagate される。"""
+        main_module, rec = patched_main
+
+        monkeypatch.setattr(
+            main_module, "download_inputs",
+            lambda **kw: (
+                rec.record("download_inputs")(**kw),
+                ["batches/x/input/deck.pptx"],
+            )[1],
+        )
+
+        def _fake_convert(input_dir, **kwargs):
+            rec.calls.append(("convert_office_files", {"input_dir": input_dir, **kwargs}))
+            return SimpleNamespace(
+                succeeded=[
+                    SimpleNamespace(
+                        original_path=Path(input_dir) / "deck.pptx",
+                        pdf_path=Path(input_dir) / "deck.pdf",
+                    )
+                ],
+                failed=[],
+            )
+
+        monkeypatch.setattr(main_module, "convert_office_files", _fake_convert)
+
+        assert main_module.main() == 0
+
+        run_async_kw = next(c for c in rec.calls if c[0] == "run_async_batch")[1]
+        viz_kw = next(c for c in rec.calls if c[0] == "generate_all_visualizations")[1]
+        apply_kw = next(c for c in rec.calls if c[0] == "apply_process_log")[1]
+
+        assert run_async_kw.get("local_to_original") == {"deck.pdf": "deck.pptx"}
+        assert viz_kw.get("original_to_local") == {"deck.pptx": "deck.pdf"}
+        assert apply_kw.get("converted_filename_map") == {"deck.pdf": "deck.pptx"}
+
+
 class TestAppendConversionFailuresHelper:
     """_append_conversion_failures_to_log の単体検証。"""
 
@@ -742,20 +907,31 @@ class TestEndToEndMixedBatch:
             # --- run_async_batch: a.pdf, deck.pdf を OCR success として
             # process_log.jsonl に直接書く。yomitoku-client が同じ log_path に追記する
             # 振る舞いを模倣 (CONVERSION_FAILED 行は main.py が先に書いている)。
+            #
+            # 新仕様 (result-filename-extension-preservation): persist パスは
+            # async_invoker が `local_to_original.get(file_path.name, file_path.name)`
+            # で解決するため、PDF native は `{name}.pdf.json`、変換後 PDF は
+            # 原本 Office 名 `{name}.pptx.json` で保存される。本 mock は
+            # async_invoker の実挙動を模擬する。
             async def _fake_run_async(**kwargs):
                 log_path = Path(kwargs["log_path"])
                 input_dir = Path(kwargs["input_dir"])
                 output_dir = Path(kwargs["output_dir"])
                 output_dir.mkdir(parents=True, exist_ok=True)
+                local_to_original = kwargs.get("local_to_original") or {}
                 # OCR 成功 PDF (a.pdf, 変換後 deck.pdf) の log エントリを追記する。
                 # CONVERSION_FAILED 行は main.py の _append_conversion_failures_to_log で
                 # 既に書かれているため、ここでは success 2 行のみ追記。
                 with log_path.open("a", encoding="utf-8") as fp:
-                    for stem in ("a", "deck"):
+                    for local_basename in ("a.pdf", "deck.pdf"):
+                        # 新仕様: output_filename = local_to_original.get(name, name)
+                        output_filename = local_to_original.get(
+                            local_basename, local_basename
+                        )
                         fp.write(json.dumps({
                             "timestamp": "2026-04-22T09:10:00.000+00:00",
-                            "file_path": str(input_dir / f"{stem}.pdf"),
-                            "output_path": str(output_dir / f"{stem}.json"),
+                            "file_path": str(input_dir / local_basename),
+                            "output_path": str(output_dir / f"{output_filename}.json"),
                             "dpi": 200,
                             "executed": True,
                             "success": True,
@@ -811,6 +987,11 @@ class TestEndToEndMixedBatch:
             assert a_item["status"] == "COMPLETED"
             assert "errorCategory" not in a_item
             assert "errorMessage" not in a_item
+            # 新仕様 (R1.1): native PDF も拡張子保持 → a.pdf.json
+            assert a_item.get("resultKey", "").endswith("/a.pdf.json"), (
+                "resultKey は native PDF でも拡張子保持: a.pdf.json のはず "
+                f"(実 {a_item.get('resultKey')})"
+            )
 
             # Bug 001 fix: deck.pptx (変換成功 → OCR success) は **deck.pptx 名のまま**
             # COMPLETED に更新される (apply_process_log が converted_filename_map で
@@ -826,9 +1007,12 @@ class TestEndToEndMixedBatch:
             )
             assert "errorCategory" not in deck_pptx_item
             assert "errorMessage" not in deck_pptx_item
-            # resultKey は変換後 PDF stem ベース (= deck.json) を指すこと
-            assert deck_pptx_item.get("resultKey", "").endswith("/deck.json"), (
-                f"resultKey は deck.json を指すはず: {deck_pptx_item.get('resultKey')}"
+            # 新仕様 (R1.2): resultKey は原本 Office 名 + ".json" 終端
+            # (deck.pptx → batches/{id}/output/deck.pptx.json)。
+            # 旧仕様 ({stem}.json = deck.json) からの変更点。
+            assert deck_pptx_item.get("resultKey", "").endswith("/deck.pptx.json"), (
+                "resultKey は deck.pptx.json (原本 Office 名 + .json) を指すはず: "
+                f"{deck_pptx_item.get('resultKey')}"
             )
 
             # Bug 001 fix: deck.pdf 名で phantom FILE 行が作られていないこと
@@ -952,12 +1136,18 @@ class TestEndToEndMixedBatch:
                 output_dir = Path(kwargs["output_dir"])
                 output_dir.mkdir(parents=True, exist_ok=True)
                 input_dir = Path(kwargs["input_dir"])
+                local_to_original = kwargs.get("local_to_original") or {}
+                # 新仕様: PDF のみバッチ → local_to_original は空 dict なので
+                # output_filename = identity ({name}.pdf)
                 with log_path.open("a", encoding="utf-8") as fp:
-                    for stem in ("a", "b"):
+                    for local_basename in ("a.pdf", "b.pdf"):
+                        output_filename = local_to_original.get(
+                            local_basename, local_basename
+                        )
                         fp.write(json.dumps({
                             "timestamp": "2026-04-22T09:10:00.000+00:00",
-                            "file_path": str(input_dir / f"{stem}.pdf"),
-                            "output_path": str(output_dir / f"{stem}.json"),
+                            "file_path": str(input_dir / local_basename),
+                            "output_path": str(output_dir / f"{output_filename}.json"),
                             "dpi": 200,
                             "executed": True,
                             "success": True,
@@ -976,6 +1166,18 @@ class TestEndToEndMixedBatch:
                 f"PDF only バッチで convert_office_files が {convert_calls['n']} 回呼ばれた "
                 "(R7.1 違反)"
             )
+
+            # PDF only バッチでは両 map が空 dict のまま下流に伝わり、
+            # native PDF identity 解決により resultKey は {name}.pdf.json になる (R5.3)
+            for fn in ("a.pdf", "b.pdf"):
+                item = table.get_item(Key={
+                    "PK": f"BATCH#{_E2E_BATCH_ID}",
+                    "SK": f"FILE#batches/{_E2E_BATCH_ID}/input/{fn}",
+                })["Item"]
+                assert item.get("resultKey", "").endswith(f"/{fn}.json"), (
+                    f"native PDF resultKey は {fn}.json (拡張子保持) のはず: "
+                    f"{item.get('resultKey')}"
+                )
 
             # META.status は COMPLETED (混在無し / 全件成功 / failed=0)
             meta = table.get_item(Key={

--- a/lambda/batch-runner/tests/test_office_converter.py
+++ b/lambda/batch-runner/tests/test_office_converter.py
@@ -42,6 +42,7 @@ from office_converter import (
     ConvertedFile,
     ConvertFailure,
     ConvertResult,
+    build_filename_maps,
     convert_office_files,
     convert_office_to_pdf,
     is_office_format,
@@ -710,3 +711,90 @@ class TestConvertOfficeFiles:
             )
         # office files = 4
         assert len(result.succeeded) + len(result.failed) == 4
+
+
+# ---------------------------------------------------------------------------
+# build_filename_maps (Task 1.1: result-filename-extension-preservation)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFilenameMaps:
+    """`build_filename_maps(convert_result)` ヘルパ関数のテスト。
+
+    Single Source of Truth (design 案 A) として `ConvertResult` から双方向の
+    filename マップ `(local_to_original, original_to_local)` を 1 箇所で
+    原子的に構築することを保証する。
+    """
+
+    def test_single_converted_file_builds_bidirectional_maps(self) -> None:
+        """単一 ConvertedFile から両 map が正しく構築される (R1.2, R1.3, R2.2, R2.3)。"""
+        convert_result = ConvertResult(
+            succeeded=[
+                ConvertedFile(
+                    original_path=Path("/in/deck.pptx"),
+                    pdf_path=Path("/in/deck.pdf"),
+                ),
+            ],
+            failed=[],
+        )
+
+        local_to_original, original_to_local = build_filename_maps(convert_result)
+
+        assert local_to_original == {"deck.pdf": "deck.pptx"}
+        assert original_to_local == {"deck.pptx": "deck.pdf"}
+
+    def test_multiple_converted_files_form_complete_inverse_relationship(self) -> None:
+        """複数 ConvertedFile で両 map が完全な逆引き関係を満たす (R1.2, R1.3, R2.2, R2.3)。
+
+        design Testing Strategy #7 invariant:
+            all(local_to_original[v] == k for k, v in original_to_local.items())
+        """
+        convert_result = ConvertResult(
+            succeeded=[
+                ConvertedFile(
+                    original_path=Path("/in/deck.pptx"),
+                    pdf_path=Path("/in/deck.pdf"),
+                ),
+                ConvertedFile(
+                    original_path=Path("/in/report.docx"),
+                    pdf_path=Path("/in/report.pdf"),
+                ),
+                ConvertedFile(
+                    original_path=Path("/in/sheet.xlsx"),
+                    pdf_path=Path("/in/sheet.pdf"),
+                ),
+            ],
+            failed=[],
+        )
+
+        local_to_original, original_to_local = build_filename_maps(convert_result)
+
+        # 期待値: 各エントリが原本ファイル名 ↔ 変換後 PDF basename の双方向対応
+        assert local_to_original == {
+            "deck.pdf": "deck.pptx",
+            "report.pdf": "report.docx",
+            "sheet.pdf": "sheet.xlsx",
+        }
+        assert original_to_local == {
+            "deck.pptx": "deck.pdf",
+            "report.docx": "report.pdf",
+            "sheet.xlsx": "sheet.pdf",
+        }
+        # invariant: 完全な逆引き関係 (entry 数同一・bidirectional)
+        assert len(local_to_original) == len(original_to_local)
+        assert len(local_to_original) == len(convert_result.succeeded)
+        assert all(
+            local_to_original[v] == k for k, v in original_to_local.items()
+        )
+        assert all(
+            original_to_local[v] == k for k, v in local_to_original.items()
+        )
+
+    def test_empty_succeeded_returns_empty_dicts(self) -> None:
+        """succeeded が空 (ネイティブ PDF のみのバッチ) では両 map とも空 dict。"""
+        convert_result = ConvertResult(succeeded=[], failed=[])
+
+        local_to_original, original_to_local = build_filename_maps(convert_result)
+
+        assert local_to_original == {}
+        assert original_to_local == {}

--- a/lambda/batch-runner/tests/test_process_log_reader.py
+++ b/lambda/batch-runner/tests/test_process_log_reader.py
@@ -20,7 +20,7 @@ class TestReadProcessLog:
             json.dumps({
                 "timestamp": "2026-04-22T10:00:00Z",
                 "file_path": "/tmp/input/a.pdf",
-                "output_path": "/tmp/output/a.json",
+                "output_path": "/tmp/output/a.pdf.json",
                 "dpi": 200,
                 "executed": True,
                 "success": True,
@@ -41,7 +41,7 @@ class TestReadProcessLog:
         assert entries[0].filename == "a.pdf"
         assert entries[0].success is True
         assert entries[0].dpi == 200
-        assert entries[0].output_path == "/tmp/output/a.json"
+        assert entries[0].output_path == "/tmp/output/a.pdf.json"
         assert entries[1].filename == "b.pdf"
         assert entries[1].success is False
         assert entries[1].error == "SageMaker timeout"
@@ -96,7 +96,7 @@ class TestReadProcessLog:
             json.dumps({
                 "timestamp": "2026-04-22T10:00:00Z",
                 "file_path": "/tmp/input/old.pdf",
-                "output_path": "/tmp/output/old.json",
+                "output_path": "/tmp/output/old.pdf.json",
                 "dpi": 200,
                 "executed": True,
                 "success": True,

--- a/lambda/batch-runner/tests/test_run_async_batch_e2e.py
+++ b/lambda/batch-runner/tests/test_run_async_batch_e2e.py
@@ -242,14 +242,15 @@ def test_e2e_mixed_success_and_failure_produces_correct_process_log(
     assert "ModelError" in fail_reason
     assert result.in_flight_timeout == []
 
-    ok_json = output_dir / "ok.json"
+    # 新仕様: persist パスは原本ファイル名 (`ok.pdf`) + `.json` 終端
+    ok_json = output_dir / "ok.pdf.json"
     assert ok_json.exists()
     assert json.loads(ok_json.read_text()) == {"pages": [{"idx": 0}]}
 
     records = _read_log(log_path)
     by_stem = {Path(r["file_path"]).stem: r for r in records}
     assert by_stem["ok"]["success"] is True
-    assert by_stem["ok"]["output_path"].endswith("ok.json")
+    assert by_stem["ok"]["output_path"].endswith("ok.pdf.json")
     assert by_stem["bad"]["success"] is False
     assert "ModelError" in by_stem["bad"]["error"]
     stubber.assert_no_pending_responses()
@@ -780,9 +781,11 @@ def test_e2e_mixed_pdf_and_pptx_via_main_run(
             f"(実 {deck_pptx_item['status']})"
         )
         assert "errorCategory" not in deck_pptx_item
-        # resultKey は実 S3 出力 (= deck.json) を指す: 変換後 stem ベース
-        assert deck_pptx_item.get("resultKey", "").endswith("/deck.json"), (
-            f"resultKey は deck.json を指すはず: {deck_pptx_item.get('resultKey')}"
+        # 新仕様 (R1.2): resultKey は原本 Office 名 (`deck.pptx.json`) を指す。
+        # 変換後 PDF basename (`deck.pdf`) ではなく、API レイヤでサニタイズ済の
+        # 原本ファイル名 + `.json` 終端で書き込まれる。
+        assert deck_pptx_item.get("resultKey", "").endswith("/deck.pptx.json"), (
+            f"resultKey は deck.pptx.json を指すはず: {deck_pptx_item.get('resultKey')}"
         )
 
         # 3d (Bug 001 fix): 変換後 deck.pdf 名で phantom FILE item が

--- a/lambda/batch-runner/tests/test_run_async_batch_e2e.py
+++ b/lambda/batch-runner/tests/test_run_async_batch_e2e.py
@@ -834,3 +834,79 @@ def test_e2e_mixed_pdf_and_pptx_via_main_run(
             f"実 {meta['status']}"
         )
         assert meta["GSI1PK"].startswith("STATUS#PARTIAL#")
+
+
+def test_e2e_pdf_only_batch_persists_extension_preserved_json(e2e_env, tmp_path):
+    """Task 5.2 / R1.1 / R5.3: ネイティブ PDF のみのバッチで新仕様
+    {原本ファイル名}.pdf.json で persist されることを E2E で検証する。
+
+    Office 形式が無いバッチでは local_to_original / original_to_local が空 dict
+    のまま下流に届き、identity 解決によって PDF にも `{name}.pdf.json` が適用
+    される (main.py の早期 init による)。
+    """
+    settings = _settings()
+    settings.success_queue_url = e2e_env.success_url
+    settings.failure_queue_url = e2e_env.failure_url
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    _write_pdf(input_dir, "alpha")
+    _write_pdf(input_dir, "beta")
+
+    _put_dummy_output(e2e_env.s3, "alpha")
+    _put_dummy_output(e2e_env.s3, "beta")
+    e2e_env.sqs.send_message(
+        QueueUrl=e2e_env.success_url,
+        MessageBody=_sns_wrap(_success_body(BATCH_JOB_ID, "alpha")),
+    )
+    e2e_env.sqs.send_message(
+        QueueUrl=e2e_env.success_url,
+        MessageBody=_sns_wrap(_success_body(BATCH_JOB_ID, "beta")),
+    )
+
+    stubber = e2e_env.stubber
+    for stem in ("alpha", "beta"):
+        stubber.add_response(
+            "invoke_endpoint_async",
+            {"InferenceId": f"{BATCH_JOB_ID}:{stem}", "OutputLocation": "s3://x/y"},
+        )
+    stubber.activate()
+
+    log_path = output_dir / "process_log.jsonl"
+    result = asyncio.run(
+        run_async_batch(
+            settings=settings,
+            input_dir=input_dir,
+            output_dir=output_dir,
+            log_path=log_path,
+            deadline_seconds=30.0,
+            local_to_original=None,  # PDF only バッチでは map なし → identity 解決
+        )
+    )
+
+    assert sorted(result.succeeded_files) == ["alpha", "beta"]
+    assert result.failed_files == []
+
+    # 新仕様: 両 PDF が {name}.pdf.json で persist されている
+    for stem in ("alpha", "beta"):
+        persisted = output_dir / f"{stem}.pdf.json"
+        assert persisted.exists(), (
+            f"R1.1 違反: ネイティブ PDF も {stem}.pdf.json で persist されるべき "
+            f"(現状 {output_dir} の中身: {[p.name for p in output_dir.iterdir()]})"
+        )
+        # 旧フォーマット {stem}.json は存在しない (R5.3: 新仕様一貫性)
+        legacy = output_dir / f"{stem}.json"  # legacy-on-purpose: negative assertion で旧仕様の不在を確認する R5.3 ガード
+        assert not legacy.exists(), (
+            f"R5.3 違反: 旧フォーマット {stem}.json が persist されている"
+        )
+
+    # process_log の output_path も新仕様
+    records = _read_log(log_path)
+    success_records = [r for r in records if r.get("success") is True]
+    assert len(success_records) == 2
+    output_paths = {Path(r["output_path"]).name for r in success_records}
+    assert output_paths == {"alpha.pdf.json", "beta.pdf.json"}, (
+        f"output_path は新仕様の {{name}}.pdf.json 形式であるはず: {output_paths}"
+    )
+    stubber.assert_no_pending_responses()

--- a/lambda/batch-runner/tests/test_runner.py
+++ b/lambda/batch-runner/tests/test_runner.py
@@ -229,6 +229,7 @@ class TestGenerateVisualizations:
     def test_generates_layout_and_ocr_per_page(
         self, reload_runner, monkeypatch, tmp_path
     ):
+        """R2.1: PDF native — 新命名規約 ``sample.pdf.json`` から ``sample.pdf`` を解決。"""
         runner = reload_runner()
         self._install_fakes(runner, monkeypatch, pages=2)
 
@@ -238,13 +239,14 @@ class TestGenerateVisualizations:
         output_dir.mkdir()
 
         (input_dir / "sample.pdf").write_bytes(b"%PDF-")
-        (output_dir / "sample.json").write_text(json.dumps({"pages": []}))
+        (output_dir / "sample.pdf.json").write_text(json.dumps({"pages": []}))
 
         errors = runner.generate_all_visualizations(
             input_dir=str(input_dir), output_dir=str(output_dir)
         )
 
         assert errors == {}
+        # JPEG basename は pdf_path.stem (= "sample") のまま据え置き (R2.4)。
         generated = sorted(p.name for p in output_dir.glob("*.jpg"))
         assert generated == [
             "sample_layout_page_0.jpg",
@@ -256,6 +258,12 @@ class TestGenerateVisualizations:
     def test_skips_json_without_matching_pdf(
         self, reload_runner, monkeypatch, tmp_path
     ):
+        """lookup miss: 対応 PDF が input_dir に不在 → silent skip + warning ログ。
+
+        ``errors_per_file`` のキーは ``original_input_name``
+        (= ``json_file.name[:-len(".json")]``)、エラーメッセージは
+        ``"local PDF not found: {local_pdf_basename}"`` (R2.4 関連)。
+        """
         runner = reload_runner()
         self._install_fakes(runner, monkeypatch)
 
@@ -264,17 +272,18 @@ class TestGenerateVisualizations:
         input_dir.mkdir()
         output_dir.mkdir()
 
-        (output_dir / "missing.json").write_text("{}")
+        (output_dir / "missing.pdf.json").write_text("{}")
 
         errors = runner.generate_all_visualizations(
             input_dir=str(input_dir), output_dir=str(output_dir)
         )
-        assert "missing" in errors
+        assert errors == {"missing.pdf": ["local PDF not found: missing.pdf"]}
         assert not list(output_dir.glob("*.jpg"))
 
     def test_collects_per_page_errors_without_aborting(
         self, reload_runner, monkeypatch, tmp_path
     ):
+        """ページ単位の失敗を収集して継続する非リグレッション (新命名規約)。"""
         runner = reload_runner()
         self._install_fakes(runner, monkeypatch, pages=2)
 
@@ -296,30 +305,31 @@ class TestGenerateVisualizations:
         input_dir.mkdir()
         output_dir.mkdir()
         (input_dir / "a.pdf").write_bytes(b"%PDF-")
-        (output_dir / "a.json").write_text("{}")
+        (output_dir / "a.pdf.json").write_text("{}")
 
         errors = runner.generate_all_visualizations(
             input_dir=str(input_dir), output_dir=str(output_dir)
         )
 
-        assert "a" in errors
-        assert any("page 0" in e for e in errors["a"])
+        # キーは original_input_name (= "a.pdf")。
+        assert "a.pdf" in errors
+        assert any("page 0" in e for e in errors["a.pdf"])
         generated = sorted(p.name for p in output_dir.glob("*.jpg"))
         assert generated == [
             "a_layout_page_1.jpg",
             "a_ocr_page_1.jpg",
         ]
 
-    def test_visualizes_converted_pdf_after_office_original_removed(
+    def test_visualizes_converted_pdf_with_office_lookup(
         self, reload_runner, monkeypatch, tmp_path
     ):
-        """R8.1-8.3 非退行: Office 原本が削除済 + 変換後 PDF のみ存在する状態でも、
-        runner.py の ``in_path / f"{basename}.pdf"`` 解決で可視化が生成される。
+        """R2.2 / R2.3: Office case — ``deck.pptx.json`` + ``original_to_local`` 経由で
+        変換後 PDF ``deck.pdf`` を逆引き解決する。
 
         office_converter.convert_office_files() は変換後に原本 (.pptx/.docx/.xlsx)
-        を削除し ``{stem}.pdf`` のみを並置するため、本テストでは事後状態
-        (input_dir に .pdf のみが存在し、原本拡張子のファイルは存在しない) を
-        再現する。
+        を削除し ``{stem}.pdf`` のみを並置する。本テストでは新命名規約
+        (``deck.pptx.json``) と双方向 map (``{"deck.pptx": "deck.pdf"}``) を渡し、
+        ``input_dir/deck.pdf`` が解決され可視化が生成されることを検証する。
         """
         runner = reload_runner()
         self._install_fakes(runner, monkeypatch, pages=2)
@@ -332,7 +342,8 @@ class TestGenerateVisualizations:
         # Office 変換後の状態: 原本 (.pptx 等) は既に削除済。
         # input_dir には変換後 PDF のみ残っている。
         (input_dir / "deck.pdf").write_bytes(b"%PDF-")
-        (output_dir / "deck.json").write_text(json.dumps({"pages": []}))
+        # メイン JSON は新命名規約 (原本ファイル名 + ".json") で保存済。
+        (output_dir / "deck.pptx.json").write_text(json.dumps({"pages": []}))
 
         # Office 原本拡張子のファイルは置かない (削除済を表現)。
         assert not list(input_dir.glob("*.pptx"))
@@ -340,11 +351,12 @@ class TestGenerateVisualizations:
         assert not list(input_dir.glob("*.xlsx"))
 
         errors = runner.generate_all_visualizations(
-            input_dir=str(input_dir), output_dir=str(output_dir)
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            original_to_local={"deck.pptx": "deck.pdf"},
         )
 
-        # PDF 可視化パイプラインがそのまま再利用され、命名規則も維持されること
-        # (R8.1 / R8.2 / R8.3)。
+        # 可視化 JPEG basename は ``pdf_path.stem`` (= "deck") のまま (R2.4 据え置き)。
         assert errors == {}
         generated = sorted(p.name for p in output_dir.glob("*.jpg"))
         assert generated == [
@@ -354,14 +366,16 @@ class TestGenerateVisualizations:
             "deck_ocr_page_1.jpg",
         ]
 
-    def test_visualizes_pdf_and_converted_pdf_are_indistinguishable(
+    def test_visualizes_pdf_and_converted_pdf_mixed(
         self, reload_runner, monkeypatch, tmp_path
     ):
-        """R8.3 非退行: 既存 PDF 入力と Office 由来の変換後 PDF が input_dir に
-        混在しても、両方とも同一の可視化命名規則で処理される。
+        """R2.3 非退行: 既存 PDF 入力と Office 由来の変換後 PDF が混在しても、
+        新命名規約 + ``original_to_local`` map で正しく逆引き解決される。
 
-        runner.py からは両者の出自を区別できず ``.pdf`` として一括処理される
-        ことを検証する。
+        - native PDF は identity (map に entry なし) で ``native.pdf.json``
+          → ``native.pdf`` に解決
+        - Office case は ``original_to_local`` 経由で ``deck.pptx.json``
+          → ``deck.pdf`` に解決
         """
         runner = reload_runner()
         self._install_fakes(runner, monkeypatch, pages=1)
@@ -373,20 +387,53 @@ class TestGenerateVisualizations:
 
         # 既存 PDF と、Office 変換後 PDF を並置 (原本拡張子は無し)。
         (input_dir / "native.pdf").write_bytes(b"%PDF-")
-        (input_dir / "converted.pdf").write_bytes(b"%PDF-")
-        (output_dir / "native.json").write_text(json.dumps({"pages": []}))
-        (output_dir / "converted.json").write_text(json.dumps({"pages": []}))
+        (input_dir / "deck.pdf").write_bytes(b"%PDF-")
+        (output_dir / "native.pdf.json").write_text(json.dumps({"pages": []}))
+        (output_dir / "deck.pptx.json").write_text(json.dumps({"pages": []}))
 
         errors = runner.generate_all_visualizations(
-            input_dir=str(input_dir), output_dir=str(output_dir)
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            original_to_local={"deck.pptx": "deck.pdf"},
         )
 
         # 両者とも同じパイプラインで処理され、エラーゼロかつ同形式の JPEG が出る。
         assert errors == {}
         generated = sorted(p.name for p in output_dir.glob("*.jpg"))
         assert generated == [
-            "converted_layout_page_0.jpg",
-            "converted_ocr_page_0.jpg",
+            "deck_layout_page_0.jpg",
+            "deck_ocr_page_0.jpg",
             "native_layout_page_0.jpg",
             "native_ocr_page_0.jpg",
         ]
+
+    def test_lookup_miss_for_office_when_map_missing_entry(
+        self, reload_runner, monkeypatch, tmp_path
+    ):
+        """lookup miss (Office): ``original_to_local`` に entry が無く、原本名
+        (``deck.pptx``) と一致する PDF も input_dir に無い場合、identity 解決で
+        ``deck.pptx`` が試行され、PDF 不在で silent skip される。
+
+        エラーメッセージは ``"local PDF not found: deck.pptx"``、キーは
+        ``original_input_name`` (= ``deck.pptx``)。
+        """
+        runner = reload_runner()
+        self._install_fakes(runner, monkeypatch)
+
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        # Office JSON のみ存在、対応 PDF は input_dir に無い (map も空)。
+        (output_dir / "deck.pptx.json").write_text("{}")
+
+        errors = runner.generate_all_visualizations(
+            input_dir=str(input_dir),
+            output_dir=str(output_dir),
+            original_to_local=None,
+        )
+
+        # identity で deck.pptx が試行される → PDF 不在で skip。
+        assert errors == {"deck.pptx": ["local PDF not found: deck.pptx"]}
+        assert not list(output_dir.glob("*.jpg"))

--- a/lambda/batch-runner/tests/test_s3_sync.py
+++ b/lambda/batch-runner/tests/test_s3_sync.py
@@ -197,11 +197,17 @@ class TestVerifyInputParity:
 
 class TestUploadOutputs:
     def _make_output_tree(self, output_dir: Path) -> None:
-        """yomitoku-client が生成するような出力ツリーを作成する。"""
-        # 結果 JSON
-        (output_dir / "sample_0.json").write_text(json.dumps({"pages": []}))
-        (output_dir / "sample_1.json").write_text(json.dumps({"pages": []}))
-        # 追加フォーマット
+        """yomitoku-client が生成するような出力ツリーを作成する。
+
+        メイン JSON は新仕様 (R1.1: {原本ファイル名}.json) で命名:
+          sample_0.pdf → sample_0.pdf.json
+          sample_1.pdf → sample_1.pdf.json
+        追加フォーマット (.md / .csv / .html / .pdf) は yomitoku-client 規約のまま。
+        """
+        # 結果 JSON (新仕様)
+        (output_dir / "sample_0.pdf.json").write_text(json.dumps({"pages": []}))
+        (output_dir / "sample_1.pdf.json").write_text(json.dumps({"pages": []}))
+        # 追加フォーマット (yomitoku-client 規約)
         (output_dir / "sample_0.md").write_text("# title")
         (output_dir / "sample_0.csv").write_text("a,b,c")
         (output_dir / "sample_0.html").write_text("<p>x</p>")
@@ -228,7 +234,7 @@ class TestUploadOutputs:
         )
 
         # カテゴリ別件数
-        assert result["output"] == 2  # sample_0.json, sample_1.json
+        assert result["output"] == 2  # sample_0.pdf.json, sample_1.pdf.json
         assert result["results"] == 4  # md, csv, html, pdf
         assert result["visualizations"] == 2  # 2 jpgs
         assert result["logs"] == 1  # process_log.jsonl
@@ -238,8 +244,8 @@ class TestUploadOutputs:
             Bucket=BUCKET, Prefix=f"batches/{BATCH_ID}/"
         )
         keys = sorted(obj["Key"] for obj in listed.get("Contents", []))
-        assert f"batches/{BATCH_ID}/output/sample_0.json" in keys
-        assert f"batches/{BATCH_ID}/output/sample_1.json" in keys
+        assert f"batches/{BATCH_ID}/output/sample_0.pdf.json" in keys
+        assert f"batches/{BATCH_ID}/output/sample_1.pdf.json" in keys
         assert f"batches/{BATCH_ID}/results/sample_0.md" in keys
         assert f"batches/{BATCH_ID}/results/sample_0.csv" in keys
         assert f"batches/{BATCH_ID}/results/sample_0.html" in keys
@@ -275,7 +281,7 @@ class TestUploadOutputs:
         (output_dir / "process_log.jsonl").write_text("{}\n")
         (output_dir / "sample.jpg").write_bytes(b"\xff\xd8")
         (output_dir / "sample.md").write_text("# x")
-        (output_dir / "sample.json").write_text("{}")
+        (output_dir / "sample.pdf.json").write_text("{}")
 
         import s3_sync
 
@@ -300,4 +306,4 @@ class TestUploadOutputs:
             "batch-content-type": "result"
         }
         # output/*.json はタグなし (長期保持)
-        assert _tags(f"batches/{BATCH_ID}/output/sample.json") == {}
+        assert _tags(f"batches/{BATCH_ID}/output/sample.pdf.json") == {}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "test:api": "pnpm --filter yomitoku-api test",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "cdk": "cdk",
-    "lint": "biome check . && bash scripts/check-legacy-refs.sh && pnpm typecheck:test",
+    "lint": "biome check . && bash scripts/check-legacy-refs.sh && bash scripts/check-result-key-format.sh && pnpm typecheck:test",
     "lint:fix": "biome check --write .",
     "lint:legacy": "bash scripts/check-legacy-refs.sh",
+    "lint:result-key": "bash scripts/check-result-key-format.sh",
     "format": "biome format --write ."
   },
   "devDependencies": {

--- a/scripts/check-result-key-format.sh
+++ b/scripts/check-result-key-format.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# check-result-key-format.sh
+# result-filename-extension-preservation の resultKey / output_path 旧フォーマット
+# ({stem}.json) の取り残しを CI で検出する契約ガード (Task 5.1)。
+#
+# 旧仕様: batches/{id}/output/{stem}.json (拡張子なし basename)
+# 新仕様: batches/{id}/output/{原本ファイル名}.json (例: report.pdf.json / deck.pptx.json)
+#
+# 検出パターン:
+#   A. Python f-string で {stem}.json / {file_stem}.json を組み立てる構築式
+#      (例: output_dir / f"{stem}.json")
+#   B. "output/<basename>.json" リテラルで basename portion に "." を含まないもの
+#      マッチ:    output/a.json, output/sample.json, output/report.json
+#      非マッチ:  output/a.pdf.json (新仕様), output/deck.pptx.json (新仕様)
+#
+# 除外:
+#   - 同行に `legacy-on-purpose` コメントを持つ行 (R5.1/R5.2 検証用の意図的旧仕様)
+#   - .kiro/, node_modules/, .git/, cdk.out/, docs/archive/, test/
+#   - scripts/check-result-key-format.sh (本 script 自身)
+#   - **/.venv/** (yomitoku-client 同梱の Python venv は対象外)
+#
+# 違反 1 件以上で exit 1、ゼロで exit 0。
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Pattern A: Python f-string で {stem}.json or {file_stem}.json を組み立てる構築式
+PATTERN_A='f"\{(file_)?stem\}\.json"'
+
+# Pattern B: "output/<basename>.json" で basename に "." を含まないもの
+#   ([a-zA-Z0-9_-]+ は "." を含まない char class なので、新仕様 {name}.{ext}.json は
+#    {name} 内の "." で char class マッチが切れて非マッチ)
+#   末尾境界 (["'),\s] のいずれか) で .json と .jsonl の誤マッチを防ぐ
+PATTERN_B='output/[a-zA-Z0-9_-]+\.json["'"'"'),[:space:]]'
+
+# 除外 pathspec (git grep の ':!' 構文)
+EXCLUDES=(
+  ':!.kiro/'
+  ':!node_modules/'
+  ':!.git/'
+  ':!cdk.out/'
+  ':!scripts/check-result-key-format.sh'
+  ':!test/'
+  ':!docs/archive/'
+  ':!**/.venv/**'
+  # 旧設計検討資料 (履歴保持のため除外。check-legacy-refs.sh と同方針)
+  ':!YomiToku-Pro_AWS構築検討.md'
+)
+
+FOUND=0
+
+# Pattern A 検出 (legacy-on-purpose マーカ付き行は除外)
+matches_a=$(git -C "$REPO_ROOT" grep -nE -- "$PATTERN_A" "${EXCLUDES[@]}" 2>/dev/null \
+  | grep -v 'legacy-on-purpose' || true)
+if [ -n "$matches_a" ]; then
+  echo "❌  Legacy {stem}.json f-string construction found:"
+  echo "$matches_a" | head -10 | sed 's/^/     /'
+  FOUND=1
+fi
+
+# Pattern B 検出 (legacy-on-purpose マーカ付き行は除外)
+matches_b=$(git -C "$REPO_ROOT" grep -nE -- "$PATTERN_B" "${EXCLUDES[@]}" 2>/dev/null \
+  | grep -v 'legacy-on-purpose' || true)
+if [ -n "$matches_b" ]; then
+  echo "❌  Legacy 'output/<basename>.json' literal (without extension preserved) found:"
+  echo "$matches_b" | head -10 | sed 's/^/     /'
+  FOUND=1
+fi
+
+echo ""
+if [ "$FOUND" -eq 1 ]; then
+  echo "✗  Legacy {stem}.json reference detected. Update to {原本ファイル名}.json (e.g., a.pdf.json)."
+  echo "    See .kiro/specs/result-filename-extension-preservation/ for the new naming convention."
+  echo "    意図的に旧フォーマットを使う場合は同行に '# legacy-on-purpose' コメントを追加。"
+  exit 1
+else
+  echo "✓  No legacy {stem}.json references found."
+  exit 0
+fi

--- a/test/check-result-key-format.test.ts
+++ b/test/check-result-key-format.test.ts
@@ -1,0 +1,70 @@
+/**
+ * check-result-key-format.sh CI guard の動作テスト (Task 5.1)
+ *
+ * - スクリプトの存在・実行可能権限を確認
+ * - package.json に lint:result-key が登録されていることを確認
+ * - クリーンなリポジトリで exit 0 を確認
+ * - 旧フォーマット { stem }.json の取り残しを検出する設計であることを assert
+ *
+ * ref: .kiro/specs/result-filename-extension-preservation/design.md
+ *      Testing Strategy > Contract Test (Legacy Reference Guard)
+ */
+
+import { spawnSync } from "node:child_process";
+import { accessSync, constants, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT = resolve(__dirname, "../scripts/check-result-key-format.sh");
+const REPO_ROOT = resolve(__dirname, "..");
+
+describe("check-result-key-format.sh CI guard (Task 5.1)", () => {
+  it("scripts/check-result-key-format.sh が存在する", () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+  });
+
+  it("スクリプトが実行可能権限を持つ", () => {
+    expect(() => accessSync(SCRIPT, constants.X_OK)).not.toThrow();
+  });
+
+  it("package.json に lint:result-key スクリプトが登録されている", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require("../package.json") as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts["lint:result-key"]).toBeDefined();
+    expect(pkg.scripts["lint:result-key"]).toContain("check-result-key-format");
+  });
+
+  it("package.json の lint チェーンに check-result-key-format.sh が組み込まれている", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require("../package.json") as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts.lint).toContain("check-result-key-format.sh");
+  });
+
+  it("クリーンなリポジトリでは exit 0 する (Task 4.1 / 4.2 fixture 移行完了の検証)", () => {
+    const result = spawnSync("bash", [SCRIPT], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        `check-result-key-format.sh exited ${result.status}.\n` +
+          `stdout:\n${result.stdout ?? ""}\n` +
+          `stderr:\n${result.stderr ?? ""}`,
+      );
+    }
+    expect(result.status).toBe(0);
+  });
+
+  it("クリーン時の成功メッセージが stdout に出力される", () => {
+    const result = spawnSync("bash", [SCRIPT], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+    const output = (result.stdout ?? "") + (result.stderr ?? "");
+    expect(output).toContain("No legacy {stem}.json references found");
+  });
+});


### PR DESCRIPTION
## 概要

OCR 結果のメイン JSON ファイル名から原本ドキュメントの拡張子が剥がれていた問題 (`report.pdf` / `deck.pptx` のいずれも `report.json` / `deck.json` で出力) を解消し、新規約 `{原本ファイル名}.json` (例: `report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`) に統一する。`office-format-ingestion` の本番リリース後、複数フォーマット混在バッチで `BatchFile.resultKey` から原本形式を機械的に判別できない問題が顕在化したため対応する。

- **Spec**: `.kiro/specs/result-filename-extension-preservation/` (requirements / design / tasks / research すべてユーザー承認済 + kiro-validate-impl で **GO** 判定)
- **コミット数**: 11 commits / 26 files / +2,283 / -111
- **テスト**: Python 197/197 + TypeScript 232/232 + API 194/194 全件 pass
- **Lint**: biome + check-legacy-refs + 新規 check-result-key-format + typecheck 全 pass

## 主な変更点

### 1. Batch Runner (`lambda/batch-runner/`)

- **`office_converter.build_filename_maps` 新規ヘルパ** (Single Source of Truth):
  - `ConvertResult` から `(local_to_original, original_to_local)` の双方向マップを 1 箇所原子的に構築
  - 双方向 map 間の drift を防止 (design Critical Issue 1 案 A 採用)
- **`async_invoker.AsyncInvoker.__init__` + `_drain_queue`**:
  - 新引数 `local_to_original: dict[str, str] | None = None` を `__init__` に追加
  - persist パスを `output_dir / f"{file_stem}.json"` から `output_dir / f"{output_filename}.json"` に変更
  - `output_filename = self._local_to_original.get(file_path.name, file_path.name)` で解決 (Office は変換後 PDF basename → 原本 Office 名、PDF はネイティブで identity)
  - SageMaker `InferenceId` 用の `_safe_ident` (SHA-1) は persist パス計算には流用しない (R1.4 invariant)
- **`runner.generate_all_visualizations`**:
  - 新引数 `original_to_local: dict[str, str] | None = None` を追加
  - lookup ロジックを `json_file.name[:-len(".json")]` で 1 段だけ剥がす方式に書換 (新仕様 `deck.pptx.json` から `deck.pptx` を正しく抽出)
  - `original_to_local.get(orig_name, orig_name)` で逆引き解決
  - 可視化 JPEG 命名 (`{basename}_{mode}_page_{idx}.jpg`) は R2.4 通り据え置き
- **`runner.run_async_batch` ラッパ**: `local_to_original` を `AsyncInvoker.__init__` に forward
- **`main.py` orchestrator**:
  - `office_converter.build_filename_maps()` で双方向マップを取得
  - `run_async_batch(local_to_original=...)` / `generate_all_visualizations(original_to_local=...)` / `apply_process_log(converted_filename_map=local_to_original)` の 3 箇所に pipe through
  - `apply_process_log` の引数名 `converted_filename_map` は維持 (Bug 001 互換維持)

### 2. API (`lambda/api/schemas.ts`)

- `BatchFile.resultKey` の OpenAPI description を 4 要素で再構成:
  1. **値フォーマット**: `batches/{batchJobId}/output/{原本ファイル名}.json` + 4 種例示 (`report.pdf.json` / `deck.pptx.json` / `report.docx.json` / `report.xlsx.json`)
  2. **移行ノート**: 旧 `{stem}.json` からの変更点と既存 consumer (basename を `.json` で 1 段剥がす実装) への影響を明示
  3. **不変 invariant**: 属性名 `resultKey` および `.json` 終端は変更なし (R4.3)
  4. **追加フォーマット非対称メモ**: yomitoku-client が出す `.md` / `.csv` / `.html` は本 spec 対象外、命名は yomitoku-client 規約のまま (将来 spec で統一の可能性あり)
- `example` を `batches/abc-123/output/document.pdf.json` に更新
- 既存情報 (`status=COMPLETED` 限定句 / `resultUrl` 案内) は losslessly 保持

### 3. 契約ガード (`scripts/check-result-key-format.sh`)

旧フォーマット `{stem}.json` の取り残しを CI で機械的に検出する新規スクリプト:
- Pattern A: `f\"{stem}.json\"` / `f\"{file_stem}.json\"` Python f-string 構築式
- Pattern B: `output/<basename>.json` リテラルで basename portion に `.` を含まないもの
- 末尾境界 (`[\"'),\\s]`) で `.json` と `.jsonl` の誤マッチを回避
- 除外: `legacy-on-purpose` コメントマーカ付き行 / `.kiro/` / `.venv/` / 旧設計検討資料 / test 配下
- `pnpm lint` チェーンに統合 + Vitest 契約テスト (`test/check-result-key-format.test.ts`) でスクリプト存在 / 実行権限 / クリーン時 exit 0 を保証

### 4. テスト (`lambda/batch-runner/tests/` + `lambda/api/__tests__/`)

- 既存 fixture 約 22 箇所を新仕様 (`{name}.json` / Office は `{name}.{ext}.json`) に書換
- 新規テストケース:
  - `TestNewNamingConvention` (PDF / Office / 非 ASCII の 3 ケース、R1.1〜R1.4)
  - `TestBuildFilenameMaps` (single / multiple / empty の 3 ケース、双方向 invariant)
  - `TestFilenameMapPropagation` (3 callsite への正確な map 注入、bijection 検証)
  - `TestResultKeyExtensionPreservation` (PDF + PPTX + DOCX + XLSX + 失敗 PPTX の 5 件混在で resultKey 全件検証)
  - `TestPreExistingResultKeyImmutability` (R5.1 / R5.2 ガード — 既存バッチの resultKey 遡及更新ゼロ)
  - `TestPendingProcessingFilesHaveNoResultKey` (R3.3 — PENDING で resultKey 不在)
  - `test_e2e_pdf_only_batch_persists_extension_preserved_json` (PDF-only E2E + R5.3 新仕様一貫性)
  - OpenAPI description 5 アサーション (R4.1 / R4.2 / R4.3 / R4.4 + 既存情報保持)

### 5. ドキュメント

- `README.md`: 結果取得 API の例示 `resultKey` を新仕様に更新

## レビュー観点

1. **Single Source of Truth**: `build_filename_maps` で双方向マップが 1 箇所構築されることで drift リスク (Bug 001 と同種) を排除している妥当性
2. **`apply_process_log` の引数名維持**: Bug 001 互換のため引数名 `converted_filename_map` を維持しつつ value だけ新変数 `local_to_original` を流用する判断
3. **Hard cutover migration**: feature flag / dual-write を採用しない判断 (Fargate task 単位 deploy で in-flight 影響なし、内部 consumer のみ)
4. **後方互換破壊**: `BatchFile.resultKey` 値フォーマット変更が API consumer (CloudFront UI 等) に与える影響と、OpenAPI description 経由の通知方針
5. **契約ガードの除外メカニズム**: `legacy-on-purpose` マーカで意図的旧仕様 (R5.1/R5.2 検証用) を明示する設計

## 後続候補

本 PR マージ後に `pnpm cdk deploy` で本番デプロイし、`sample-pdf/` の PDF + サンプル PPTX を投入して `BatchFile.resultKey` が新仕様 (`.pdf.json` / `.pptx.json`) で生成されることを実機確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)